### PR TITLE
Doc: Migration from standalone to integration plugin

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,9 +26,9 @@ The SNMP integration plugin includes:
 * SNMP input plugin
 * SNMPtrap input plugin
 
--//Uncomment and replace with above bullets after generated the initial versions of the target files
--// - {logstash-ref}/plugins-input-snmp.html[SNMP input plugin]
--// - {logstash-ref}/plugins-input-snmptrap.html[Snmptrap input plugin]
+// Uncomment and replace with above bullets after generated the initial versions of the target files
+// - {logstash-ref}/plugins-input-snmp.html[SNMP input plugin]
+// - {logstash-ref}/plugins-input-snmptrap.html[Snmptrap input plugin]
 
 The new the `logstash-integration-snmp` plugin combines the 
 `logstash-input-snmp` and `logstash-input-snmptrap` plugins into one integrated plugin that encompasses
@@ -87,7 +87,7 @@ You might need to address some behavior changes depending on your use case and h
 ====== Changes to mapping and error logging: `logstash-input-snmptrap`
 
 * The *PDU variable bindings* are mapped into the {ls} event using the defined data type. 
-  By default, the integrated `logstash-input-snmptrap` plugin converts all of the data to `string`, ignoring the original type. 
+  By default, the stand-alone `logstash-input-snmptrap` plugin converts all of the data to `string`, ignoring the original type. 
   If this behavior is not what you want, you can use a filter to retain the original type.
 * *SNMP `TimeTicks` variables* are mapped as `Long` timestamps instead of formatted date string (`%d days, %02d:%02d:%02d.%02d`).
 * *`null` variables values* are mapped using the string `null` instead of `Null` (upper-case N).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,15 +17,121 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === SNMP Integration Plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+// include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-The SNMP Integration Plugin provides integrated plugins for working with SNMP:
+The SNMP integration plugin includes:
 
-//Uncomment after generated the initial versions of the target files
-// - {logstash-ref}/plugins-input-snmp.html[SNMP input plugin]
-// - {logstash-ref}/plugins-input-snmptrap.html[Snmptrap input plugin]
+* SNMP input plugin
+* SNMPtrap input plugin
+
+-//Uncomment and replace with above bullets after generated the initial versions of the target files
+-// - {logstash-ref}/plugins-input-snmp.html[SNMP input plugin]
+-// - {logstash-ref}/plugins-input-snmptrap.html[Snmptrap input plugin]
+
+The new the `logstash-integration-snmp` plugin combines the 
+`logstash-input-snmp` and `logstash-input-snmptrap` plugins into one integrated plugin that encompasses
+the capabilities of both. 
+This integrated plugin package provides better alignment in snmp processing, better resource managenment, 
+easier package maintenance, and a smaller installation footprint. 
+
+In this section, we'll cover:
+
+* <<plugins-{type}s-{plugin}-migration>>
+* <<plugins-{type}s-{plugin}-import-mibs>>
+
+[id="plugins-{type}s-{plugin}-migration"]
+==== Migrating to `logstash-integration-snmp` from individual plugins
+
+You'll retain and expand the functionality of existing stand-alone plugins, but in a more compact, integrated package. 
+In this section, we'll note mapping and behavioral changes, and explain how to preserve current behavior if needed.
+
+[IMPORTANT] 
+--
+Uninstall the `logstash-input-snmp` and `logstash-input-snmptrap` plugins _before_ you install the `logstash-integration-snmp` plugin. 
+
+* `bin/logstash-plugin remove logstash-input-snmp` +
+* `bin/logstash-plugin remove logstash-input-snmptrap`
+--
+
+// ToDo: Add guidance and set expectations for when snmp integration is installed by default
+
+[id="plugins-{type}s-{plugin}-migration-input-snmp"]
+===== Migration notes: `logstash-input-snmp` 
+
+As a component of the new `logstash-integration-snmp` plugin, the `logstash-input-snmp` plugin offers the same 
+capabilities as the stand-alone https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp]. 
+
+You might need to address some behavior changes depending on the use-case and how the ingested data is being handled through the pipeline.
+
+
+[id="plugins-{type}s-{plugin}-input-snmp-mapping"]
+====== Changes to mapping and error logging: `logstash-input-snmp`
+
+* *No such instance errors* are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
+* *No such object errors* are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
+* *End of MIB view errors* are mapped as `error: end of MIB view` instead of `endOfMibView`.
+* An *unknown variable type* falls back to the `string` representation instead of logging an error as it did in with the stand-alone `logstash-input-snmp`.
+This change should not affect existing pipelines, unless they have custom error handlers that rely on specific error messages.
+
+[id="plugins-{type}s-{plugin}-migration-input-snmptrap"]
+===== Migration notes: `logstash-input-snmptrap`
+
+As a component of the new `logstash-integration-snmp` plugin, the `logstash-input-snmptrap` plugin offers _almost the same 
+capabilities_ as the stand-alone https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp] plugin. 
+
+You might need to address some behavior changes depending on your use case and how the ingested data is being handled through the pipeline.
+
+[id="plugins-{type}s-{plugin}-input-snmptrap-mapping"]
+====== Changes to mapping and error logging: `logstash-input-snmptrap`
+
+* The *PDU variable bindings* are mapped into the {ls} event using the defined data type. 
+  By default, the integrated `logstash-input-snmptrap` plugin converts all of the data to `string`, ignoring the original type. 
+  If this behavior is not what you want, you can use a filter to retain the original type.
+* *SNMP `TimeTicks` variables* are mapped as `Long` timestamps instead of formatted date string (`%d days, %02d:%02d:%02d.%02d`).
+* *`null` variables values* are mapped using the string `null` instead of `Null` (upper-case N).
+* *No such instance errors* are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
+* *No such object errors* are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
+* *End of MIB view errors* are mapped as `error: end of MIB view` instead of `endOfMibView`.
+* The previous generation (stand-alone) input-snmptrap plugin formatted the *`message` field* as
+a ruby-snmp `SNMP::SNMPv1_Trap` object representation.  
++
+[source,sh]
+----
+<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring", @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6,  @enterprise=[1.2.3.4.5.6], @source_ip="127.0.0.1", @agent_addr=#<SNMP::IpAddress:0x29a4833e @value="test">, @specific_trap=99>
+----
++
+The new integrated `input-snmptrap` plugin uses JSON to format *`message` field*.
++
+[source,json]
+----
+{"error_index":0, "variable_bindings":{"1.3.6.1.6.3.1.1.4.1.0":"SNMPv2-MIB::coldStart", "1.3.6.1.2.1.1.3.0":0}, "error_status":0, "type":"TRAP", "error_status_text":"Success", "community":"public", "version":"2c", "request_id":1436216872}
+----
+
+// ToDo: Add more details wrt PDU variable binding.  Which filter? Add sample config? 
+
+[id="plugins-{type}s-{plugin}-input-snmptrap-compat"]
+====== Maintain maximum compatibility with previous implementation
+
+If needed, you can configure the new `logstash-integration-snmp` plugin to maintain maximum compatibility with the previous (stand-alone) 
+version of the https://github.com/logstash-plugins/logstash-input-snmp[input-snmp] plugin.
+
+[source,ruby]
+----
+input {
+   snmptrap {
+    use_provided_mibs => false
+    oid_mapping_format => 'ruby_snmp'
+    oid_map_field_values => true
+   }
+}
+----
+
+// ToDo: Any considerations that we should point out? 
+
+:no_codec!:
+
 
 [id="plugins-{type}s-{plugin}-import-mibs"]
 ==== Importing MIBs

--- a/docs/input-snmp.asciidoc
+++ b/docs/input-snmp.asciidoc
@@ -399,15 +399,6 @@ Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Pr
 
 The `security_name` option specifies the SNMPv3 security name or user name.
 
-[id="plugins-{type}s-{plugin}-use_provided_mibs"]
-===== `use_provided_mibs`
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-This plugin provides all IETF MIBs (management information bases), publicly available in the https://www.ibr.cs.tu-bs.de/projects/libsmi[libsmi] version `0.5.0`.
-When enabled, it automatically loads the bundled MIBs and provides mapping of the numeric OIDs to MIB field names in the resulting event.
-
 [id="plugins-{type}s-{plugin}-examples"]
 ==== Configuration examples
 

--- a/docs/input-snmp.asciidoc
+++ b/docs/input-snmp.asciidoc
@@ -494,4 +494,19 @@ input {
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+[id="plugins-{type}s-{plugin}-migration-guide-input-snmp"]
+==== Migrating from logstash-input-snmp
+
+The `logstash-integration-snmp` `snmp` input plugin does support the same https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp] functionalities. There are a few changes that might
+need to be addressed depending on the use-case, and how the ingested data is being handled through the pipeline:
+
+* No such instance errors are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
+* No such object errors are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
+* End of MIB view errors are mapped as `error: end of MIB view` instead of `endOfMibView`.
+* Unlike the https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp], this plugin fallbacks unknown variable types to its `string` representation instead of logging an error.
+It shouldn't affect existing pipelines, unless they have custom error handlers relying on specific error messages.
+
+NOTE: The https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp]
+plugin must be removed before installing this plugin.
+
 :no_codec!:

--- a/docs/input-snmp.asciidoc
+++ b/docs/input-snmp.asciidoc
@@ -18,8 +18,8 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === SNMP input plugin
 
-//Uncomment after generated the initial versions of the target file
-//include::{include_path}/plugin_header-integration.asciidoc[]
+// Uncomment after generated the initial versions of the target file
+// include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
@@ -27,6 +27,17 @@ The SNMP input polls network devices using Simple Network Management Protocol (S
 to gather information related to the current state of the devices operation.
 
 The SNMP input plugin supports SNMP v1, v2c, and v3 over UDP and TCP transport protocols.
+
+.Migrating to `logstash-integration-snmp` from stand-alone `input-snmp`
+**** 
+The `logstash-input-snmp` plugin is now a component of the `logstash-integration-snmp` plugin. 
+This integrated plugin package provides better alignment in snmp processing, better resource management, 
+easier package maintenance, and a smaller installation footprint. 
+
+For migration information and guidelines, check out the migration guide.
+**** 
+
+// TODO: Add link to migration topic in the integration index. 
 
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
@@ -47,8 +58,11 @@ Metadata fields follow a specific naming convention when <<plugins-{type}s-{plug
 [id="plugins-{type}s-{plugin}-import-mibs"]
 ==== Importing MIBs 
 
-This plugin already includes the IETF MIBs (management information bases) and these do not need to be imported.
-Any other MIB will need to be manually imported following the {logstash-ref}/plugins-integrations-snmp.html[Importing MIBs] guideline.
+This plugin already includes the IETF MIBs (management information bases), and you do not need to import them.
+If you need additional MIBs, you need to important them.  
+Check out "Importing MIBs" for instructions.
+
+// ToDo: Add link to MIBs content after generated file exists.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== SNMP Input Configuration Options
@@ -484,20 +498,5 @@ input {
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
-
-[id="plugins-{type}s-{plugin}-migration-guide-input-snmp"]
-==== Migrating from logstash-input-snmp
-
-The `logstash-integration-snmp` `snmp` input plugin does support the same https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp] functionalities. There are a few changes that might
-need to be addressed depending on the use-case, and how the ingested data is being handled through the pipeline:
-
-* No such instance errors are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
-* No such object errors are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
-* End of MIB view errors are mapped as `error: end of MIB view` instead of `endOfMibView`.
-* Unlike the https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp], this plugin fallbacks unknown variable types to its `string` representation instead of logging an error.
-It shouldn't affect existing pipelines, unless they have custom error handlers relying on specific error messages.
-
-NOTE: The https://github.com/logstash-plugins/logstash-input-snmp[logstash-input-snmp]
-plugin must be removed before installing this plugin.
 
 :no_codec!:

--- a/docs/input-snmptrap.asciidoc
+++ b/docs/input-snmptrap.asciidoc
@@ -366,4 +366,53 @@ input {
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+[id="plugins-{type}s-{plugin}-migration-guide-input-snmptrap"]
+==== Migrating from logstash-input-snmptrap
+
+The `logstash-integration-snmp` `snmptrap` input plugin can be configured for maximum compatibility with the https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap] plugin:
+
+[source,ruby]
+----
+input {
+   snmptrap {
+    use_provided_mibs => false
+    oid_mapping_format => 'ruby_snmp'
+    oid_map_field_values => true
+   }
+}
+
+----
+
+Although the plugin functionality will be almost the same as the https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap] plugin, there are a few changes that might
+need to be addressed depending on the use-case, and how the ingested data is being handled through the pipeline:
+
+* The received PDU variable bindings are mapped into the Logstash's event using the defined data type.
+By default, `logstash-input-snmptrap` converts all the data to `string`, ignoring the original type. If this
+behavior is desired, a filter can be used to achieve the same results.
+* SNMP `TimeTicks` variables are mapped as `Long` timestamps instead of formatted date string (`%d days, %02d:%02d:%02d.%02d`).
+* `null` variables values are mapped using the string `null` instead of `Null` (upper-case N).
+* No such instance errors are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
+* No such object errors are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
+* End of MIB view errors are mapped as `error: end of MIB view` instead of `endOfMibView`.
+
+Another major difference is how the `message` field is mapped. `logstash-input-snmptrap` formats the `message` field as
+a ruby-snmp `SNMP::SNMPv1_Trap` object representation, whereas this integration plugin uses JSON. For example:
+
+`logstash-input-snmptrap`:
+
+[source]
+----
+<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring", @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6,  @enterprise=[1.2.3.4.5.6], @source_ip="127.0.0.1", @agent_addr=#<SNMP::IpAddress:0x29a4833e @value="test">, @specific_trap=99>
+----
+
+`logstash-integration-snmptrap`:
+
+[source,json]
+----
+{"error_index":0, "variable_bindings":{"1.3.6.1.6.3.1.1.4.1.0":"SNMPv2-MIB::coldStart", "1.3.6.1.2.1.1.3.0":0}, "error_status":0, "type":"TRAP", "error_status_text":"Success", "community":"public", "version":"2c", "request_id":1436216872}
+----
+
+NOTE: The https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap]
+plugin must be removed before installing this plugin.
+
 :default_codec!:

--- a/docs/input-snmptrap.asciidoc
+++ b/docs/input-snmptrap.asciidoc
@@ -23,12 +23,22 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 ==== Description
 
-Read SNMP trap messages as events
+The `logstash-input-snmptrap` plugin reads SNMP trap messages as events.
 
 Resulting `message` field resembles:
 [source,ruby]
 {"agent_addr"=>"192.168.1.40", "generic_trap"=>6, "specific_trap"=>15511, "enterprise"=>"1.3.6.1.2.1.1.1", "variable_bindings"=>{"1.3.6.1.2.1.1.2.0"=>"test one", "1.3.6.1.2.1.1.1.0"=>"test two"}, "type"=>"V1TRAP", "community"=>"public", "version"=>1, "timestamp"=>1500}
 
+.Migrating to `logstash-integration-snmp` from stand-alone `input-snmptrap`
+**** 
+The `logstash-input-snmptrap` plugin is now a component of the `logstash-integration-snmp` plugin. 
+This integrated plugin package provides better alignment in snmp processing, better resource management, 
+easier package maintenance, and a smaller installation footprint. 
+
+For migration information and guidelines, check out the migration guide.
+**** 
+
+// TODO: Add link to migration topic in the integration index. 
 
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Event Metadata and the Elastic Common Schema (ECS)
@@ -67,8 +77,12 @@ which variable binding in the list caused the error
 [id="plugins-{type}s-{plugin}-import-mibs"]
 ==== Importing MIBs
 
-This plugin already includes the IETF MIBs (management information bases) and these do not need to be imported.
-Any other MIB will need to be manually imported following the {logstash-ref}/plugins-integrations-snmp.html[Importing MIBs] guideline.
+This plugin already includes the IETF MIBs (management information bases), and you do not need to import them.
+If you need additional MIBs, you need to important them.  
+Check out "Importing MIBs" for instructions.
+
+// ToDo: Add link to MIBs content after generated file exists.
+
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== SNMP Trap Input Configuration Options
@@ -365,54 +379,5 @@ input {
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
-
-[id="plugins-{type}s-{plugin}-migration-guide-input-snmptrap"]
-==== Migrating from logstash-input-snmptrap
-
-The `logstash-integration-snmp` `snmptrap` input plugin can be configured for maximum compatibility with the https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap] plugin:
-
-[source,ruby]
-----
-input {
-   snmptrap {
-    use_provided_mibs => false
-    oid_mapping_format => 'ruby_snmp'
-    oid_map_field_values => true
-   }
-}
-
-----
-
-Although the plugin functionality will be almost the same as the https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap] plugin, there are a few changes that might
-need to be addressed depending on the use-case, and how the ingested data is being handled through the pipeline:
-
-* The received PDU variable bindings are mapped into the Logstash's event using the defined data type.
-By default, `logstash-input-snmptrap` converts all the data to `string`, ignoring the original type. If this
-behavior is desired, a filter can be used to achieve the same results.
-* SNMP `TimeTicks` variables are mapped as `Long` timestamps instead of formatted date string (`%d days, %02d:%02d:%02d.%02d`).
-* `null` variables values are mapped using the string `null` instead of `Null` (upper-case N).
-* No such instance errors are mapped as `error: no such instance currently exists at this OID string` instead of `noSuchInstance`.
-* No such object errors are mapped as `error: no such object currently exists at this OID string` instead of `noSuchObject`.
-* End of MIB view errors are mapped as `error: end of MIB view` instead of `endOfMibView`.
-
-Another major difference is how the `message` field is mapped. `logstash-input-snmptrap` formats the `message` field as
-a ruby-snmp `SNMP::SNMPv1_Trap` object representation, whereas this integration plugin uses JSON. For example:
-
-`logstash-input-snmptrap`:
-
-[source]
-----
-<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring", @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6,  @enterprise=[1.2.3.4.5.6], @source_ip="127.0.0.1", @agent_addr=#<SNMP::IpAddress:0x29a4833e @value="test">, @specific_trap=99>
-----
-
-`logstash-integration-snmptrap`:
-
-[source,json]
-----
-{"error_index":0, "variable_bindings":{"1.3.6.1.6.3.1.1.4.1.0":"SNMPv2-MIB::coldStart", "1.3.6.1.2.1.1.3.0":0}, "error_status":0, "type":"TRAP", "error_status_text":"Success", "community":"public", "version":"2c", "request_id":1436216872}
-----
-
-NOTE: The https://github.com/logstash-plugins/logstash-input-snmptrap[logstash-input-snmptrap]
-plugin must be removed before installing this plugin.
 
 :default_codec!:


### PR DESCRIPTION
Starts with @edmocosta's great work in #14 and expands it. 

#### Design intent

* The migration steps are necessary because of the new integration plugin that pulls in input-snmp and input-snmptrap.  The migration content is big news for now and needs to be super-obvious. For that reason, I recommend that we include the migration info in the integration topic and link to it from banners in the the component plugins.  With this approach, we don't have to decide between adding heavy, "moment in time" content to the beginning of a topic where it will push down other content, OR add it to the end where it might be missed. 

* Note that distinguishing between old and new versions of the snmp inputs is tricky. I tried to be as precise as possible, and starting introducing language such as "preview version," "stand-alone," "next generation," and so forth. I'm bound to find more instances where we need to be more clear, but this is start. Comments on the terminology I'm using are always welcome. 

* You'll notice `snmp` and `snmptrap` repeated in headings and sub-headings. This is intentional. Users often scan content or can land in a section from a search. The repetition is designed to clearly indicate which plugin flavor the section applies to without leaving that responsibility to the user.

* Disclaimer: In order to validate structure and formatting, I had to mock up files because the integration plugin isn't generating doc files yet.  This hack makes it easy to obscure problems with formats and links, so hang on! 

@edmocosta, thanks for your great work on this.  Let's discuss this approach and decide on next steps. 

Fixes: #11
