### PR TITLE
Fix unit and integration tests

### DIFF
--- a/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
+++ b/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
@@ -62,7 +62,7 @@ public class SnmpTestTrapSender {
         send(pdu, target);
     }
 
-    void sendTrapV2c(String address, String community, Map<String, Object> bindings) {
+    public void sendTrapV2c(String address, String community, Map<String, Object> bindings) {
         final PDU pdu = new PDU();
         pdu.setType(PDU.TRAP);
         addVariableBindings(pdu, bindings);
@@ -77,7 +77,7 @@ public class SnmpTestTrapSender {
         send(pdu, target);
     }
 
-    void sendTrapV3(
+    public void sendTrapV3(
             String address,
             String securityName,
             String authProtocol,

--- a/src/main/java/org/logstash/snmp/mib/MibManager.java
+++ b/src/main/java/org/logstash/snmp/mib/MibManager.java
@@ -79,7 +79,7 @@ public class MibManager {
         return Collections.unmodifiableMap(mibFileReaders);
     }
 
-    OidFieldMapper getFieldMapper() {
+    public OidFieldMapper getFieldMapper() {
         return fieldMapper;
     }
 }


### PR DESCRIPTION
Unit and integration tests are failing after upgrading Gradle. It seems the error only happen with `ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env`, which runs Java 17 and for some reason, started to fail with the new Gradle version.

This PR makes the methods used by the tests `public`, solving the issue.

---
Closes: https://github.com/logstash-plugins/logstash-integration-snmp/issues/63