### PR TITLE
Remove explicit dep on jar-dependencies

### DIFF
--- a/logstash-integration-snmp.gemspec
+++ b/logstash-integration-snmp.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   }
 
   # Gem dependencies
-  s.add_development_dependency 'jar-dependencies', '~> 0.3'
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'


### PR DESCRIPTION
Jruby ships with a version of this gem. Managing with bundler causes load issues.

See https://github.com/elastic/ingest-dev/issues/4691