### PR TITLE
Support SNMPv3 Informs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.3
+  - Support SNMPv3 Informs [#89](https://github.com/logstash-plugins/logstash-integration-snmp/pull/89)
+
 ## 4.2.2
   - Re-packaging the plugin [#86](https://github.com/logstash-plugins/logstash-integration-snmp/pull/86)
 

--- a/docs/input-snmp.asciidoc
+++ b/docs/input-snmp.asciidoc
@@ -213,6 +213,7 @@ If polling all configured hosts takes longer than this interval, a warning will 
   * There is no default value for this setting
 
 The SNMPv3 local engine ID. Its length must be greater or equal than 5 and less or equal than 32.
+When prefixed with `0x`, the value is interpreted as hexadecimal bytes, for example `0x80001f88806763084db5aebf6600000000`.
 If not provided, a default ID is generated based on the local IP address and additional four random bytes.
 
 [id="plugins-{type}s-{plugin}-mib_paths"]

--- a/docs/input-snmptrap.asciidoc
+++ b/docs/input-snmptrap.asciidoc
@@ -252,6 +252,16 @@ which would result in a field name "1.0". Similarly when a MIB is used an OID su
 The port to listen on. Remember that ports less than 1024 (privileged
 ports) may require root to use. hence the default of 1062.
 
+[id="plugins-{type}s-{plugin}-local_engine_id"]
+===== `local_engine_id`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting
+
+The SNMPv3 local engine ID. Its length must be greater or equal than 5 and less or equal than 32.
+When prefixed with `0x`, the value is interpreted as hexadecimal bytes, for example `0x80001f88806763084db5aebf6600000000`.
+If not provided, a default ID is generated based on the local IP address and additional four random bytes.
+
 [id="plugins-{type}s-{plugin}-supported_transports"]
 ===== `supported_transports`
   * Value type is <<string,string>>

--- a/docs/input-snmptrap.asciidoc
+++ b/docs/input-snmptrap.asciidoc
@@ -94,12 +94,14 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-community>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-local_engine_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-mib_paths>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-oid_mapping_format>> |<<string,string>>, one of `["default", "ruby_snmp", "dotted_string"]`|No
 | <<plugins-{type}s-{plugin}-oid_map_field_values>> |<<boolean,boolean>>|Yes
 | <<plugins-{type}s-{plugin}-oid_path_length>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-oid_root_skip>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-snmpv3_inform_resync>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-supported_transports>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-supported_versions>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
@@ -261,6 +263,32 @@ ports) may require root to use. hence the default of 1062.
 The SNMPv3 local engine ID. Its length must be greater or equal than 5 and less or equal than 32.
 When prefixed with `0x`, the value is interpreted as hexadecimal bytes, for example `0x80001f88806763084db5aebf6600000000`.
 If not provided, a default ID is generated based on the local IP address and additional four random bytes.
+
+[NOTE]
+====
+When <<plugins-{type}s-{plugin}-snmpv3_inform_resync>> is enabled, the plugin persists its local engine boots value and the learned SNMPv3 timeliness cache under `path.data/plugins/inputs/snmp` so they can survive Logstash restarts.
+If there is only one `snmptrap` input in a pipeline, the filename is a SHA-256 hash derived from the plugin type and the pipeline id.
+If `pipelines.yml` sets `pipeline.id: jsa-snmp-input-filter`, that pipeline id becomes part of the hash, so the same pipeline keeps the same persistence filename across restarts.
+
+When multiple `snmptrap` inputs share a pipeline, the hash also uses the configured plugin `id` when it was explicitly set, together with the listen host and port, so each instance can keep separate state.
+
+This means separate pipelines get separate state files automatically.
+If you run multiple `snmptrap` inputs in the same pipeline and want them isolated from each other, set an explicit `id` on each plugin instance.
+Auto-generated plugin ids are not used for this key so ordinary restarts continue to reuse the same state file.
+====
+
+[id="plugins-{type}s-{plugin}-snmpv3_inform_resync"]
+===== `snmpv3_inform_resync`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When enabled, the plugin persists its SNMPv3 local engine boots state so INFORM senders can resynchronize after a restart.
+If a sender receives a `usmNotInTimeWindow` REPORT, SNMP4J uses the returned `engineBoots` and `engineTime` values to refresh its local timeliness table and retry the INFORM.
+This setting persists the plugin's local engine boots counter together with remote SNMPv3 engine timeliness data learned during REPORT-based resynchronization.
+On the receiver side, the first stale INFORM after a restart can still be rejected and logged as `usmStatsNotInTimeWindows` while the sender learns the updated timeliness values and retries.
+
+This setting only affects SNMPv3 INFORM interoperability. It does not change how traps are decoded.
 
 [id="plugins-{type}s-{plugin}-supported_transports"]
 ===== `supported_transports`

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -57,10 +57,6 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   # The default, `30`, means poll each host every 30 seconds.
   config :interval, :validate => :number, :default => 30
 
-  # The optional SNMPv3 engine's administratively-unique identifier.
-  # Its length must be greater or equal than 5 and less or equal than 32.
-  config :local_engine_id, :validate => :string
-
   # Number of threads to use for concurrently executing the hosts SNMP requests.
   config :threads, :validate => :number, :required => true, :default => ::LogStash::Config::CpuCoreStrategy.maximum
 
@@ -303,25 +299,12 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
     end
   end
 
-  def validate_local_engine_id!
-    return if @local_engine_id.nil?
-
-    if @local_engine_id.length < 5
-      raise(LogStash::ConfigurationError, '`local_engine_id` length must be greater or equal than 5')
-    end
-
-    if @local_engine_id.length > 32
-      raise(LogStash::ConfigurationError, '`local_engine_id` length must be lower or equal than 32')
-    end
-  end
-
   def create_request_aggregator
     SnmpClientRequestAggregator.new(@threads, 'SnmpRequestWorker')
   end
 
   def build_client!(mib_manager, supported_transports, hosts_versions)
     client_builder = org.logstash.snmp.SnmpClient.builder(mib_manager, supported_transports)
-    client_builder.setLocalEngineId(@local_engine_id) unless @local_engine_id.nil?
 
     build_snmp_client!(client_builder, validate_usm_user: hosts_versions.include?('3'))
   end

--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -117,6 +117,8 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
   private
 
   def validate_config!
+    validate_local_engine_id!
+
     if !@security_name.nil? && !@supported_versions.include?('3')
       raise(LogStash::ConfigurationError, "Using a `security_name` requires `supported_versions` to include version '3': #{@supported_versions}")
     end

--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -60,6 +60,10 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
   # by the message dispatcher, so it won't block the listener thread.
   config :threads, :validate => :number, :required => true, :default => ::LogStash::Config::CpuCoreStrategy.seventy_five_percent
 
+  # When enabled, the plugin persists its SNMPv3 local engine boots so INFORM senders can
+  # resynchronize after a usmNotInTimeWindow report.
+  config :snmpv3_inform_resync, :validate => :boolean, :default => false
+
   # These MIBs were automatically added by ruby-snmp when no @yamlmibdir was provided.
   MIB_DEFAULT_PATHS = [
     ::File.join(MIB_BASE_PATH, 'ietf', 'SNMPv2-SMI.dic'),
@@ -132,7 +136,11 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
                         .setMessageDispatcherPoolName('SnmpTrapMessageDispatcherWorker')
                         .setMessageDispatcherPoolSize(@threads)
 
-    build_snmp_client!(client_builder, validate_usm_user: @supported_versions.include?('3'))
+    build_snmp_client!(
+      client_builder,
+      validate_usm_user: @supported_versions.include?('3'),
+      persist_engine_boots: @snmpv3_inform_resync
+    )
   end
 
   def consume_trap_message(output_queue, trap_message)

--- a/lib/logstash/plugin_mixins/snmp/common.rb
+++ b/lib/logstash/plugin_mixins/snmp/common.rb
@@ -4,12 +4,15 @@ module LogStash
       # This module provides common configurations and functions to all SNMP plugins
       #
       module Common
+        HEX_LOCAL_ENGINE_ID_REGEX = /\A0x[0-9A-Fa-f]+\z/.freeze
+
         require 'logstash-integration-snmp_jars'
 
         java_import 'org.logstash.snmp.RubySnmpOidFieldMapper'
         java_import 'org.logstash.snmp.DefaultOidFieldMapper'
         java_import 'org.logstash.snmp.DottedStringOidFieldMapper'
         java_import 'org.logstash.snmp.mib.MibManager'
+        java_import 'org.snmp4j.smi.OctetString'
 
         OID_MAPPING_FORMAT_DEFAULT = 'default'.freeze
         OID_MAPPING_FORMAT_RUBY_SNMP = 'ruby_snmp'.freeze
@@ -69,6 +72,10 @@ module LogStash
           # The target is only relevant while decoding data into a new event.
           base.config :target, :validate => :field_reference
 
+          # The optional SNMPv3 engine's administratively-unique identifier.
+          # Its length must be greater or equal than 5 and less or equal than 32.
+          base.config :local_engine_id, :validate => :string
+
           # SNMPv3 Credentials
           #
           # A single user can be configured and will be used for all defined SNMPv3 requests.
@@ -121,6 +128,7 @@ module LogStash
             client_builder.addUsmUser(@security_name, @auth_protocol, @auth_pass&.value, @priv_protocol, @priv_pass&.value, @security_level || 'noAuthNoPriv')
           end
 
+          set_local_engine_id!(client_builder) unless @local_engine_id.nil?
           client_builder.setMapOidVariableValues(@oid_map_field_values)
           client_builder.build
         end
@@ -149,6 +157,68 @@ module LogStash
           else
             raise(LogStash::ConfigurationError, 'The `oid_root_skip` and `oid_path_length` requires setting `oid_mapping_format` to `default`') if @oid_root_skip.positive? || @oid_path_length.positive?
           end
+        end
+
+        def validate_local_engine_id!
+          return if @local_engine_id.nil?
+
+          if local_engine_id_bytesize < 5
+            raise(LogStash::ConfigurationError, '`local_engine_id` length must be greater or equal than 5')
+          end
+
+          if local_engine_id_bytesize > 32
+            raise(LogStash::ConfigurationError, '`local_engine_id` length must be lower or equal than 32')
+          end
+        end
+
+        def set_local_engine_id!(client_builder)
+          if local_engine_id_hex?
+            local_engine_id_bytes = [@local_engine_id[2..]].pack('H*').to_java_bytes
+
+            if client_builder.respond_to?(:java_send)
+              begin
+                client_builder.java_send(:setLocalEngineId, [Java::byte[]], local_engine_id_bytes)
+              rescue NameError
+                set_local_engine_id_bytes_with_reflection!(client_builder, local_engine_id_bytes)
+              end
+            elsif client_builder.respond_to?(:java_class)
+              set_local_engine_id_bytes_with_reflection!(client_builder, local_engine_id_bytes)
+            else
+              client_builder.setLocalEngineId(local_engine_id_bytes)
+            end
+          else
+            client_builder.setLocalEngineId(@local_engine_id)
+          end
+        end
+
+        def local_engine_id_bytesize
+          if local_engine_id_hex?
+            hex_body = @local_engine_id[2..]
+
+            unless hex_body.length.even?
+              raise(LogStash::ConfigurationError, '`local_engine_id` must contain an even number of hexadecimal digits when using the `0x` prefix')
+            end
+
+            hex_body.length / 2
+          else
+            @local_engine_id.bytesize
+          end
+        end
+
+        def local_engine_id_hex?
+          return false unless @local_engine_id.start_with?('0x')
+
+          unless @local_engine_id.match?(HEX_LOCAL_ENGINE_ID_REGEX)
+            raise(LogStash::ConfigurationError, '`local_engine_id` must be a valid hexadecimal string when using the `0x` prefix')
+          end
+
+          true
+        end
+
+        def set_local_engine_id_bytes_with_reflection!(client_builder, local_engine_id_bytes)
+          local_engine_id_field = client_builder.java_class.declared_fields.find { |field| field.name == 'localEngineId' }
+          local_engine_id_field.setAccessible(true)
+          local_engine_id_field.set(client_builder, OctetString.new(local_engine_id_bytes))
         end
 
         def validate_usm_user!

--- a/lib/logstash/plugin_mixins/snmp/common.rb
+++ b/lib/logstash/plugin_mixins/snmp/common.rb
@@ -217,6 +217,13 @@ module LogStash
 
         def set_local_engine_id_bytes_with_reflection!(client_builder, local_engine_id_bytes)
           local_engine_id_field = client_builder.java_class.declared_fields.find { |field| field.name == 'localEngineId' }
+
+          unless local_engine_id_field
+            raise(
+              LogStash::ConfigurationError,
+              "Unable to set `local_engine_id`: SNMP client builder #{client_builder.java_class.name} does not expose the expected `localEngineId` field"
+            )
+          end
           local_engine_id_field.setAccessible(true)
           local_engine_id_field.set(client_builder, OctetString.new(local_engine_id_bytes))
         end

--- a/lib/logstash/plugin_mixins/snmp/common.rb
+++ b/lib/logstash/plugin_mixins/snmp/common.rb
@@ -6,7 +6,9 @@ module LogStash
       module Common
         HEX_LOCAL_ENGINE_ID_REGEX = /\A0x[0-9A-Fa-f]+\z/.freeze
 
+        require 'digest'
         require 'logstash-integration-snmp_jars'
+        require 'tmpdir'
 
         java_import 'org.logstash.snmp.RubySnmpOidFieldMapper'
         java_import 'org.logstash.snmp.DefaultOidFieldMapper'
@@ -121,13 +123,14 @@ module LogStash
           mib_manager
         end
 
-        def build_snmp_client!(client_builder, validate_usm_user: false)
+        def build_snmp_client!(client_builder, validate_usm_user: false, persist_engine_boots: true)
           validate_usm_user! if validate_usm_user
 
           unless @security_name.nil?
             client_builder.addUsmUser(@security_name, @auth_protocol, @auth_pass&.value, @priv_protocol, @priv_pass&.value, @security_level || 'noAuthNoPriv')
           end
 
+          client_builder.setEngineBootsPersistencePath(engine_boots_state_file_path) if persist_engine_boots
           set_local_engine_id!(client_builder) unless @local_engine_id.nil?
           client_builder.setMapOidVariableValues(@oid_map_field_values)
           client_builder.build
@@ -221,11 +224,125 @@ module LogStash
           unless local_engine_id_field
             raise(
               LogStash::ConfigurationError,
-              "Unable to set `local_engine_id`: SNMP client builder #{client_builder.java_class.name} does not expose the expected `localEngineId` field"
+              'Unable to set `local_engine_id`: SNMP client builder does not expose the `localEngineId` field for the reflective fallback'
             )
           end
+
           local_engine_id_field.setAccessible(true)
           local_engine_id_field.set(client_builder, OctetString.new(local_engine_id_bytes))
+        end
+
+        def engine_boots_state_file_path
+          state_root = logstash_data_path || ::Dir.tmpdir
+          state_key = engine_boots_state_key
+
+          ::File.join(state_root, 'plugins', 'inputs', 'snmp', "#{Digest::SHA256.hexdigest(state_key)}.engineboots")
+        end
+
+        def engine_boots_state_key
+          if single_plugin_instance_in_pipeline?
+            [plugin_state_namespace, pipeline_state_key].compact.join('|')
+          else
+            [
+              plugin_state_namespace,
+              pipeline_state_key,
+              explicit_plugin_id_state_key,
+              @host,
+              @port,
+              normalized_hosts_state_key
+            ].compact.join('|')
+          end
+        end
+
+        def plugin_state_namespace
+          self.class.respond_to?(:config_name) ? self.class.config_name : self.class.name
+        end
+
+        def normalized_hosts_state_key
+          return nil unless instance_variable_defined?(:@hosts) && @hosts
+
+          @hosts
+            .map { |host| host.sort_by { |key, _value| key.to_s }.map { |key, value| "#{key}=#{value}" }.join(',') }
+            .sort
+            .join(';')
+        end
+
+        def pipeline_state_key
+          pipeline = execution_context.pipeline
+          return nil if pipeline.nil?
+
+          return pipeline.pipeline_id if pipeline.respond_to?(:pipeline_id)
+          return pipeline.id if pipeline.respond_to?(:id)
+
+          nil
+        rescue StandardError
+          nil
+        end
+
+        def explicit_plugin_id_state_key
+          return nil unless respond_to?(:original_params)
+          return nil unless original_params.is_a?(Hash)
+
+          plugin_id = original_params['id'] || original_params[:id]
+          return nil if generated_plugin_id?(plugin_id)
+
+          plugin_id
+        rescue StandardError
+          nil
+        end
+
+        def generated_plugin_id?(plugin_id)
+          return false if plugin_id.nil?
+
+          plugin_id.match?(generated_plugin_id_pattern)
+        end
+
+        def generated_plugin_id_pattern
+          /\A#{Regexp.escape(config_name)}_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+        end
+
+        def single_plugin_instance_in_pipeline?
+          pipeline_plugins = pipeline_plugins_for_state_key
+          return false unless pipeline_plugins.respond_to?(:one?)
+
+          pipeline_plugins.one?
+        rescue StandardError
+          false
+        end
+
+        def pipeline_plugins_for_state_key
+          pipeline = execution_context.pipeline
+          return [] if pipeline.nil?
+
+          collection_name = pipeline_plugin_collection_name
+          return [] unless pipeline.respond_to?(collection_name)
+
+          Array(pipeline.public_send(collection_name)).select do |plugin|
+            plugin.respond_to?(:config_name) && plugin.config_name == config_name
+          end
+        rescue StandardError
+          []
+        end
+
+        def pipeline_plugin_collection_name
+          case @plugin_type
+          when 'input'
+            :inputs
+          when 'filter'
+            :filters
+          when 'output'
+            :outputs
+          else
+            :plugins
+          end
+        end
+
+        def logstash_data_path
+          return nil unless defined?(LogStash::SETTINGS)
+
+          LogStash::SETTINGS.get_value('path.data')
+        rescue StandardError
+          nil
         end
 
         def validate_usm_user!

--- a/spec/integration/inputs/snmptrap_spec.rb
+++ b/spec/integration/inputs/snmptrap_spec.rb
@@ -121,6 +121,24 @@ describe LogStash::Inputs::Snmptrap, :integration => true do
         let(:config) { super().merge('supported_transports' => ['udp']) }
 
         it_behaves_like 'a plugin receiving a v2c or v3 trap message', '2c'
+
+        it 'acknowledges informs' do
+          inform_acknowledged = false
+
+          queue = run_plugin_and_get_queue(plugin) do
+            bindings = { '1.3.6.1.2.1.1.1.0' => 'It is a 2c inform' }
+            inform_acknowledged = @trap_sender.send_inform_v2c(target_address, community, bindings)
+          end
+
+          expect(inform_acknowledged).to be(true)
+          expect(queue.size).to be(1)
+
+          trap_event = queue.pop
+          expect(trap_event.get('iso.org.dod.internet.mgmt.mib-2.system.sysDescr.0')).to eq('It is a 2c inform')
+          expect(trap_event.get("#{PDU_METADATA}[version]")).to eq('2c')
+          expect(trap_event.get("#{PDU_METADATA}[type]")).to eq('INFORM')
+          expect(trap_event.get("#{PDU_METADATA}[community]")).to eq(community)
+        end
       end
 
       context 'when receiving a message over TCP' do
@@ -167,6 +185,31 @@ describe LogStash::Inputs::Snmptrap, :integration => true do
         let(:config) { super().merge('supported_transports' => ['udp']) }
 
         it_behaves_like 'a plugin receiving a v2c or v3 trap message', '3'
+
+        context 'with `local_engine_id` set as a hexadecimal string' do
+          let(:config) do
+            super().merge('local_engine_id' => '0x80001f88806763084db5aebf6600000000')
+          end
+
+          it_behaves_like 'a plugin receiving a v2c or v3 trap message', '3'
+        end
+
+        it 'acknowledges informs' do
+          inform_acknowledged = false
+
+          queue = run_plugin_and_get_queue(plugin) do
+            bindings = { '1.3.6.1.2.1.1.1.0' => 'It is a 3 inform' }
+            inform_acknowledged = @trap_sender.send_inform_v3(target_address, security_name, auth_protocol, auth_pass, priv_protocol, priv_pass, security_level, bindings)
+          end
+
+          expect(inform_acknowledged).to be(true)
+          expect(queue.size).to be(1)
+
+          trap_event = queue.pop
+          expect(trap_event.get('iso.org.dod.internet.mgmt.mib-2.system.sysDescr.0')).to eq('It is a 3 inform')
+          expect(trap_event.get("#{PDU_METADATA}[version]")).to eq('3')
+          expect(trap_event.get("#{PDU_METADATA}[type]")).to eq('INFORM')
+        end
       end
 
       context 'when receiving a message over TCP' do

--- a/spec/integration/inputs/snmptrap_spec.rb
+++ b/spec/integration/inputs/snmptrap_spec.rb
@@ -210,6 +210,7 @@ describe LogStash::Inputs::Snmptrap, :integration => true do
           expect(trap_event.get("#{PDU_METADATA}[version]")).to eq('3')
           expect(trap_event.get("#{PDU_METADATA}[type]")).to eq('INFORM')
         end
+
       end
 
       context 'when receiving a message over TCP' do

--- a/spec/unit/inputs/common_spec.rb
+++ b/spec/unit/inputs/common_spec.rb
@@ -138,6 +138,32 @@ shared_examples 'a common SNMP plugin' do
   context '#build_snmp_client!' do
     let(:client_builder) { double('org.logstash.snmp.SnmpClientBuilder') }
 
+    context 'with `local_engine_id` set' do
+      let(:config) { super().merge('local_engine_id' => '0123456789') }
+
+      it 'sets the client local engine id' do
+        expect(client_builder).to receive(:setLocalEngineId).with('0123456789')
+        expect(client_builder).to receive(:setMapOidVariableValues)
+        expect(client_builder).to receive(:build)
+
+        plugin.build_snmp_client!(client_builder)
+      end
+    end
+
+    context 'with `local_engine_id` set as a hexadecimal string' do
+      let(:config) { super().merge('local_engine_id' => '0x80001f88806763084db5aebf6600000000') }
+
+      it 'sets the client local engine id using decoded bytes' do
+        expected_engine_id = ['80001f88806763084db5aebf6600000000'].pack('H*').to_java_bytes
+
+        expect(client_builder).to receive(:setLocalEngineId).with(expected_engine_id)
+        expect(client_builder).to receive(:setMapOidVariableValues)
+        expect(client_builder).to receive(:build)
+
+        plugin.build_snmp_client!(client_builder)
+      end
+    end
+
     context 'with USM user validation' do
       let(:config) { super().merge('security_name' => 'public') }
 
@@ -231,6 +257,85 @@ shared_examples 'a common SNMP plugin' do
             end
           end
         end
+      end
+    end
+  end
+
+  describe 'local_engine_id validation' do
+    let(:local_engine_id) { nil }
+    let(:config) { super().merge('local_engine_id' => local_engine_id) }
+
+    before(:each) do
+      allow(plugin).to receive(:build_client!).and_return(mock_client)
+    end
+
+    context 'with length lower than 5' do
+      let(:local_engine_id) { '1234' }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` length must be greater or equal than 5'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
+      end
+    end
+
+    context 'with valid length' do
+      let(:local_engine_id) { '0' * 32 }
+
+      it 'should not raise' do
+        expect { plugin.register }.to_not raise_error
+      end
+    end
+
+    context 'with valid hexadecimal length' do
+      let(:local_engine_id) { '0x80001f88806763084db5aebf6600000000' }
+
+      it 'should not raise' do
+        expect { plugin.register }.to_not raise_error
+      end
+    end
+
+    context 'with invalid hexadecimal content' do
+      let(:local_engine_id) { '0x80001f88806763084db5aebf66000000ZZ' }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` must be a valid hexadecimal string when using the `0x` prefix'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
+      end
+    end
+
+    context 'with an odd number of hexadecimal digits' do
+      let(:local_engine_id) { '0x12345' }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` must contain an even number of hexadecimal digits when using the `0x` prefix'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
+      end
+    end
+
+    context 'with hexadecimal content shorter than 5 bytes' do
+      let(:local_engine_id) { '0x01020304' }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` length must be greater or equal than 5'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
+      end
+    end
+
+    context 'with length greater than 32' do
+      let(:local_engine_id) { '0' * 33 }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` length must be lower or equal than 32'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
+      end
+    end
+
+    context 'with hexadecimal content greater than 32 bytes' do
+      let(:local_engine_id) { '0x' + ('ab' * 33) }
+
+      it 'should raise' do
+        error_message = '`local_engine_id` length must be lower or equal than 32'
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
       end
     end
   end

--- a/spec/unit/inputs/common_spec.rb
+++ b/spec/unit/inputs/common_spec.rb
@@ -1,4 +1,5 @@
 require 'logstash/devutils/rspec/spec_helper'
+require 'digest'
 require_relative '../../../lib/logstash/inputs/snmp'
 require_relative '../../../lib/logstash/inputs/snmptrap'
 
@@ -138,6 +139,20 @@ shared_examples 'a common SNMP plugin' do
   context '#build_snmp_client!' do
     let(:client_builder) { double('org.logstash.snmp.SnmpClientBuilder') }
 
+    before(:each) do
+      allow(client_builder).to receive(:setEngineBootsPersistencePath)
+    end
+
+    it 'sets the engine boots persistence path' do
+      allow(plugin).to receive(:engine_boots_state_file_path).and_return('/tmp/snmp.engineboots')
+
+      expect(client_builder).to receive(:setEngineBootsPersistencePath).with('/tmp/snmp.engineboots')
+      expect(client_builder).to receive(:setMapOidVariableValues)
+      expect(client_builder).to receive(:build)
+
+      plugin.build_snmp_client!(client_builder)
+    end
+
     context 'with `local_engine_id` set' do
       let(:config) { super().merge('local_engine_id' => '0123456789') }
 
@@ -161,6 +176,18 @@ shared_examples 'a common SNMP plugin' do
         expect(client_builder).to receive(:build)
 
         plugin.build_snmp_client!(client_builder)
+      end
+
+      it 'raises a clear configuration error when the reflective fallback cannot find the engine id field' do
+        java_class = double('java_class', :declared_fields => [])
+        reflective_builder = double('reflective_builder', :java_class => java_class)
+
+        expect do
+          plugin.send(:set_local_engine_id_bytes_with_reflection!, reflective_builder, ['80001f88806763084db5aebf6600000000'].pack('H*').to_java_bytes)
+        end.to raise_error(
+          LogStash::ConfigurationError,
+          'Unable to set `local_engine_id`: SNMP client builder does not expose the `localEngineId` field for the reflective fallback'
+        )
       end
     end
 
@@ -258,6 +285,62 @@ shared_examples 'a common SNMP plugin' do
           end
         end
       end
+    end
+  end
+
+  describe '#engine_boots_state_file_path' do
+    before(:each) do
+      allow(plugin).to receive(:logstash_data_path).and_return('/tmp/logstash-data')
+    end
+
+    it 'extracts the pipeline id when available' do
+      allow(plugin).to receive(:execution_context).and_return(double('context', :pipeline => double('pipeline', :pipeline_id => 'main')))
+
+      expect(plugin.send(:pipeline_state_key)).to eq('main')
+    end
+
+    it 'uses the helper state keys when building the path' do
+      allow(plugin).to receive(:pipeline_state_key).and_return('main')
+      allow(plugin).to receive(:explicit_plugin_id_state_key).and_return('trap-a')
+      allow(plugin).to receive(:single_plugin_instance_in_pipeline?).and_return(false)
+      allow(Digest::SHA256).to receive(:hexdigest).and_return('state-key-digest')
+
+      expected_state_key = [
+        plugin.class.config_name,
+        'main',
+        'trap-a',
+        plugin.instance_variable_get(:@host),
+        plugin.instance_variable_get(:@port),
+        plugin.send(:normalized_hosts_state_key)
+      ].compact.join('|')
+
+      expect(plugin.send(:engine_boots_state_file_path)).to eq('/tmp/logstash-data/plugins/inputs/snmp/state-key-digest.engineboots')
+      expect(Digest::SHA256).to have_received(:hexdigest).with(expected_state_key)
+    end
+
+    it 'uses only the plugin type and pipeline id when there is a single plugin instance in the pipeline' do
+      allow(plugin).to receive(:pipeline_state_key).and_return('jsa-snmp-input-filter')
+      allow(plugin).to receive(:single_plugin_instance_in_pipeline?).and_return(true)
+      allow(Digest::SHA256).to receive(:hexdigest).and_return('state-key-digest')
+
+      expect(plugin.send(:engine_boots_state_file_path)).to eq('/tmp/logstash-data/plugins/inputs/snmp/state-key-digest.engineboots')
+      expect(Digest::SHA256).to have_received(:hexdigest).with("#{plugin.class.config_name}|jsa-snmp-input-filter")
+    end
+
+    it 'includes the explicit plugin id when configured' do
+      plugin_with_id = described_class.new(config.merge('id' => 'trap-a'))
+      expect(plugin_with_id.send(:explicit_plugin_id_state_key)).to eq('trap-a')
+    end
+
+    it 'does not include an auto-generated plugin id when it was not configured' do
+      expect(plugin.send(:explicit_plugin_id_state_key)).to be_nil
+    end
+
+    it 'detects a single plugin instance from the pipeline execution context' do
+      pipeline = double('pipeline', :inputs => [plugin])
+      allow(plugin).to receive(:execution_context).and_return(double('context', :pipeline => pipeline))
+
+      expect(plugin.send(:single_plugin_instance_in_pipeline?)).to be(true)
     end
   end
 

--- a/spec/unit/inputs/snmp_spec.rb
+++ b/spec/unit/inputs/snmp_spec.rb
@@ -181,37 +181,6 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
     end
   end
 
-  describe 'local_engine_id validation' do
-    let(:local_engine_id) { nil }
-    let(:config) { super().merge('get' => ["1.0"], 'hosts' => [{'host' => "udp:127.0.0.1/161", "version" => "2c"}], 'local_engine_id' => local_engine_id) }
-
-    context 'with length lower than 5' do
-      let(:local_engine_id) { '1234' }
-
-      it 'should raise' do
-        error_message = '`local_engine_id` length must be greater or equal than 5'
-        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
-      end
-    end
-
-    context 'with valid length' do
-      let(:local_engine_id) { '0' * 32 }
-
-      it 'should not raise' do
-        expect { plugin.register }.to_not raise_error
-      end
-    end
-
-    context 'with length greater than 32' do
-      let(:local_engine_id) { '0' * 33 }
-
-      it 'should raise' do
-        error_message = '`local_engine_id` length must be lower or equal than 32'
-        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, error_message)
-      end
-    end
-  end
-
   ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
     let(:queue) { Queue.new }
     let(:run_once_runner) { RunOnceStoppableIntervalRunner.new(plugin) }

--- a/spec/unit/inputs/snmptrap_spec.rb
+++ b/spec/unit/inputs/snmptrap_spec.rb
@@ -38,6 +38,44 @@ describe LogStash::Inputs::Snmptrap, :ecs_compatibility_support do
     end
   end
 
+  describe '#build_client!' do
+    let(:mib_manager) { double('org.logstash.snmp.mib.MibManager') }
+    let(:client_builder) { double('org.logstash.snmp.SnmpClientBuilder') }
+    let(:config) { super().merge('supported_versions' => ['3']) }
+
+    before(:each) do
+      allow(org.logstash.snmp.SnmpClient).to receive(:builder).and_return(client_builder)
+      allow(client_builder).to receive(:setHost).and_return(client_builder)
+      allow(client_builder).to receive(:setSupportedVersions).and_return(client_builder)
+      allow(client_builder).to receive(:setMessageDispatcherPoolName).and_return(client_builder)
+      allow(client_builder).to receive(:setMessageDispatcherPoolSize).and_return(client_builder)
+    end
+
+    it 'does not persist engine boots for inform resynchronization by default' do
+      expect(plugin).to receive(:build_snmp_client!).with(
+        client_builder,
+        validate_usm_user: true,
+        persist_engine_boots: false
+      )
+
+      plugin.send(:build_client!, mib_manager)
+    end
+
+    context 'when `snmpv3_inform_resync` is enabled' do
+      let(:config) { super().merge('snmpv3_inform_resync' => true) }
+
+      it 'persists engine boots for inform resynchronization' do
+        expect(plugin).to receive(:build_snmp_client!).with(
+          client_builder,
+          validate_usm_user: true,
+          persist_engine_boots: true
+        )
+
+        plugin.send(:build_client!, mib_manager)
+      end
+    end
+  end
+
   ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
     let(:config) { super().merge 'ecs_compatibility' => ecs_select.active_mode }

--- a/src/main/java/org/logstash/snmp/EngineBootsStore.java
+++ b/src/main/java/org/logstash/snmp/EngineBootsStore.java
@@ -1,0 +1,377 @@
+package org.logstash.snmp;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.snmp4j.security.UsmTimeEntry;
+import org.snmp4j.security.UsmTimeTable;
+import org.snmp4j.smi.OctetString;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Properties;
+
+final class EngineBootsStore {
+    private static final Logger logger = LogManager.getLogger(EngineBootsStore.class);
+    private static final String ENGINE_BOOTS_KEY = "engine_boots";
+    private static final String LOCAL_ENGINE_ID_KEY = "local_engine_id";
+    private static final String REMOTE_ENTRY_PREFIX = "remote.";
+    private static final String REMOTE_ENGINE_BOOTS_SUFFIX = ".engine_boots";
+    private static final String REMOTE_TIME_DIFF_SUFFIX = ".time_diff";
+    private static final Field USM_TIME_TABLE_FIELD = resolveUsmTimeTableField();
+
+    private EngineBootsStore() {
+    }
+
+    static synchronized OctetString resolveLocalEngineId(
+            final String persistencePath,
+            final OctetString localEngineId
+    ) {
+        if (persistencePath == null || persistencePath.isBlank()) {
+            return localEngineId;
+        }
+
+        final Path statePath = Paths.get(persistencePath);
+        if (!Files.exists(statePath)) {
+            return localEngineId;
+        }
+
+        final Properties properties = loadProperties(statePath);
+        final String persistedEngineId = properties.getProperty(LOCAL_ENGINE_ID_KEY);
+        if (persistedEngineId == null || persistedEngineId.isBlank()) {
+            return localEngineId;
+        }
+
+        try {
+            return new OctetString(decodeEngineId(persistedEngineId));
+        } catch (RuntimeException e) {
+            logger.warn("Unable to read persisted SNMP local engine ID from {}. Reusing a newly generated local engine ID.",
+                    statePath,
+                    e);
+            return localEngineId;
+        }
+    }
+
+    static synchronized int nextEngineBoots(final String persistencePath, final OctetString localEngineId) {
+        if (persistencePath == null || persistencePath.isBlank()) {
+            return 0;
+        }
+
+        final Path statePath = Paths.get(persistencePath);
+        final String engineId = encodeEngineId(localEngineId);
+        final Properties properties = new Properties();
+        int engineBoots = 0;
+
+        try {
+            if (Files.exists(statePath)) {
+                try (InputStream inputStream = Files.newInputStream(statePath)) {
+                    properties.load(inputStream);
+                }
+
+                if (localEngineIdMatches(properties.getProperty(LOCAL_ENGINE_ID_KEY), localEngineId)) {
+                    engineBoots = incrementEngineBoots(properties.getProperty(ENGINE_BOOTS_KEY));
+                } else {
+                    clearRemoteEngineTimeEntries(properties);
+                }
+            }
+
+            properties.setProperty(LOCAL_ENGINE_ID_KEY, engineId);
+            properties.setProperty(ENGINE_BOOTS_KEY, Integer.toString(engineBoots));
+            persist(statePath, properties);
+            return engineBoots;
+        } catch (Exception e) {
+            logger.warn("Unable to persist SNMP engine boots state at {}. Falling back to a non-persistent local engine boots counter.",
+                    persistencePath,
+                    e);
+            return 0;
+        }
+    }
+
+    static synchronized void persistRemoteEngineTimeEntries(
+            final String persistencePath,
+            final OctetString localEngineId,
+            final UsmTimeTable timeTable
+    ) {
+        if (persistencePath == null || persistencePath.isBlank()) {
+            return;
+        }
+
+        final Path statePath = Paths.get(persistencePath);
+        final Properties properties = loadProperties(statePath);
+        properties.setProperty(LOCAL_ENGINE_ID_KEY, encodeEngineId(localEngineId));
+        clearRemoteEngineTimeEntries(properties);
+
+        for (PersistedRemoteEngineTime remoteEngineTime : snapshotRemoteEngineTimes(timeTable, localEngineId)) {
+            final String keyPrefix = REMOTE_ENTRY_PREFIX + remoteEngineTime.engineId;
+            properties.setProperty(keyPrefix + REMOTE_ENGINE_BOOTS_SUFFIX, Integer.toString(remoteEngineTime.engineBoots));
+            properties.setProperty(keyPrefix + REMOTE_TIME_DIFF_SUFFIX, Integer.toString(remoteEngineTime.timeDiff));
+        }
+
+        try {
+            persist(statePath, properties);
+        } catch (IOException e) {
+            logger.warn("Unable to persist SNMP engine time cache at {}. Continuing with in-memory timeliness data.",
+                    persistencePath,
+                    e);
+        }
+    }
+
+    static synchronized List<UsmTimeEntry> loadRemoteEngineTimeEntries(
+            final String persistencePath,
+            final OctetString localEngineId
+    ) {
+        if (persistencePath == null || persistencePath.isBlank()) {
+            return List.of();
+        }
+
+        final Path statePath = Paths.get(persistencePath);
+        if (!Files.exists(statePath)) {
+            return List.of();
+        }
+
+        final Properties properties = loadProperties(statePath);
+        if (!localEngineIdMatches(properties.getProperty(LOCAL_ENGINE_ID_KEY), localEngineId)) {
+            return List.of();
+        }
+
+        final List<UsmTimeEntry> remoteEntries = new ArrayList<>();
+        final int currentTime = currentTimeSeconds();
+
+        for (PersistedRemoteEngineTime remoteEngineTime : readRemoteEngineTimeEntries(properties)) {
+            final int engineTime = currentTime + remoteEngineTime.timeDiff;
+            remoteEntries.add(new UsmTimeEntry(
+                    new OctetString(decodeEngineId(remoteEngineTime.engineId)),
+                    remoteEngineTime.engineBoots,
+                    engineTime
+            ));
+        }
+
+        return remoteEntries;
+    }
+
+    static String remoteEngineTimeSignature(final UsmTimeTable timeTable, final OctetString localEngineId) {
+        final StringBuilder signature = new StringBuilder();
+
+        for (PersistedRemoteEngineTime remoteEngineTime : snapshotRemoteEngineTimes(timeTable, localEngineId)) {
+            if (signature.length() > 0) {
+                signature.append('|');
+            }
+            signature.append(remoteEngineTime.engineId)
+                    .append(':')
+                    .append(remoteEngineTime.engineBoots)
+                    .append(':')
+                    .append(remoteEngineTime.timeDiff);
+        }
+
+        return signature.toString();
+    }
+
+    private static int incrementEngineBoots(final String value) {
+        try {
+            final int storedValue = Integer.parseInt(value);
+            if (storedValue < 0) {
+                return 0;
+            }
+            if (storedValue == Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            return storedValue + 1;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static Properties loadProperties(final Path statePath) {
+        final Properties properties = new Properties();
+
+        try (InputStream inputStream = Files.newInputStream(statePath)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            logger.warn("Unable to read SNMP engine state from {}. Recreating the persistence file.", statePath, e);
+        }
+
+        return properties;
+    }
+
+    private static List<PersistedRemoteEngineTime> snapshotRemoteEngineTimes(
+            final UsmTimeTable timeTable,
+            final OctetString localEngineId
+    ) {
+        final List<PersistedRemoteEngineTime> remoteEntries = new ArrayList<>();
+        final Hashtable<?, ?> entries = extractRemoteTimeTableEntries(timeTable);
+
+        for (Object value : entries.values()) {
+            if (!(value instanceof UsmTimeEntry)) {
+                continue;
+            }
+
+            final UsmTimeEntry entry = (UsmTimeEntry) value;
+            if (entry.getEngineID().equals(localEngineId)) {
+                continue;
+            }
+
+            remoteEntries.add(new PersistedRemoteEngineTime(
+                    encodeEngineId(entry.getEngineID()),
+                    entry.getEngineBoots(),
+                    entry.getTimeDiff()
+            ));
+        }
+
+        remoteEntries.sort(Comparator.comparing(remoteEngineTime -> remoteEngineTime.engineId));
+        return remoteEntries;
+    }
+
+    private static List<PersistedRemoteEngineTime> readRemoteEngineTimeEntries(final Properties properties) {
+        final List<PersistedRemoteEngineTime> remoteEntries = new ArrayList<>();
+
+        for (String key : properties.stringPropertyNames()) {
+            if (!key.startsWith(REMOTE_ENTRY_PREFIX) || !key.endsWith(REMOTE_ENGINE_BOOTS_SUFFIX)) {
+                continue;
+            }
+
+            final String engineId = key.substring(REMOTE_ENTRY_PREFIX.length(), key.length() - REMOTE_ENGINE_BOOTS_SUFFIX.length());
+            final String timeDiffKey = REMOTE_ENTRY_PREFIX + engineId + REMOTE_TIME_DIFF_SUFFIX;
+            final String engineBootsValue = properties.getProperty(key);
+            final String timeDiffValue = properties.getProperty(timeDiffKey);
+
+            if (timeDiffValue == null) {
+                continue;
+            }
+
+            try {
+                remoteEntries.add(new PersistedRemoteEngineTime(
+                        engineId,
+                        Integer.parseInt(engineBootsValue),
+                        Integer.parseInt(timeDiffValue)
+                ));
+            } catch (RuntimeException e) {
+                logger.warn("Unable to parse SNMP engine time cache entry for engine {}. Skipping it.", engineId, e);
+            }
+        }
+
+        remoteEntries.sort(Comparator.comparing(remoteEngineTime -> remoteEngineTime.engineId));
+        return remoteEntries;
+    }
+
+    private static Hashtable<?, ?> extractRemoteTimeTableEntries(final UsmTimeTable timeTable) {
+        try {
+            return (Hashtable<?, ?>) USM_TIME_TABLE_FIELD.get(timeTable);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Unable to access SNMP4J USM time table entries", e);
+        }
+    }
+
+    private static Field resolveUsmTimeTableField() {
+        try {
+            final Field tableField = UsmTimeTable.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            return tableField;
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("Unable to locate SNMP4J USM time table storage", e);
+        }
+    }
+
+    private static void clearRemoteEngineTimeEntries(final Properties properties) {
+        final List<String> remoteKeys = new ArrayList<>();
+        for (String key : properties.stringPropertyNames()) {
+            if (key.startsWith(REMOTE_ENTRY_PREFIX)) {
+                remoteKeys.add(key);
+            }
+        }
+        remoteKeys.forEach(properties::remove);
+    }
+
+    private static int currentTimeSeconds() {
+        return (int) (System.nanoTime() / 1_000_000_000L);
+    }
+
+    private static boolean localEngineIdMatches(final String persistedEngineId, final OctetString localEngineId) {
+        if (persistedEngineId == null || persistedEngineId.isBlank()) {
+            return false;
+        }
+
+        try {
+            return new OctetString(decodePersistedEngineId(persistedEngineId)).equals(localEngineId);
+        } catch (RuntimeException e) {
+            logger.warn("Unable to parse persisted SNMP local engine ID {}. Recreating the persistence file.", persistedEngineId, e);
+            return false;
+        }
+    }
+
+    private static String encodeEngineId(final OctetString engineId) {
+        final byte[] bytes = engineId.getValue();
+        final StringBuilder builder = new StringBuilder(bytes.length * 2);
+
+        for (byte value : bytes) {
+            builder.append(Character.forDigit((value >> 4) & 0x0F, 16));
+            builder.append(Character.forDigit(value & 0x0F, 16));
+        }
+
+        return builder.toString();
+    }
+
+    private static byte[] decodePersistedEngineId(final String encodedEngineId) {
+        if (encodedEngineId.indexOf(':') >= 0) {
+            return OctetString.fromHexString(encodedEngineId).getValue();
+        }
+
+        return decodeEngineId(encodedEngineId);
+    }
+
+    private static byte[] decodeEngineId(final String encodedEngineId) {
+        if ((encodedEngineId.length() & 1) != 0) {
+            throw new IllegalArgumentException("SNMP engine ID must contain an even number of hexadecimal digits");
+        }
+
+        final byte[] decoded = new byte[encodedEngineId.length() / 2];
+        for (int index = 0; index < encodedEngineId.length(); index += 2) {
+            decoded[index / 2] = (byte) Integer.parseInt(encodedEngineId.substring(index, index + 2), 16);
+        }
+
+        return decoded;
+    }
+
+    private static final class PersistedRemoteEngineTime {
+        private final String engineId;
+        private final int engineBoots;
+        private final int timeDiff;
+
+        private PersistedRemoteEngineTime(final String engineId, final int engineBoots, final int timeDiff) {
+            this.engineId = engineId;
+            this.engineBoots = engineBoots;
+            this.timeDiff = timeDiff;
+        }
+    }
+
+    private static void persist(final Path statePath, final Properties properties) throws IOException {
+        final Path parent = statePath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        final Path tempFile = Files.createTempFile(parent, statePath.getFileName().toString(), ".tmp");
+        try {
+            try (OutputStream outputStream = Files.newOutputStream(tempFile,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                properties.store(outputStream, "SNMP engine boots state");
+            }
+
+            Files.move(tempFile, statePath,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+}

--- a/src/main/java/org/logstash/snmp/PersistentUsm.java
+++ b/src/main/java/org/logstash/snmp/PersistentUsm.java
@@ -1,0 +1,130 @@
+package org.logstash.snmp;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.snmp4j.TransportStateReference;
+import org.snmp4j.asn1.BERInputStream;
+import org.snmp4j.asn1.BEROutputStream;
+import org.snmp4j.mp.StatusInformation;
+import org.snmp4j.mp.SnmpConstants;
+import org.snmp4j.security.SecurityModel;
+import org.snmp4j.security.SecurityParameters;
+import org.snmp4j.security.SecurityProtocols;
+import org.snmp4j.security.SecurityStateReference;
+import org.snmp4j.security.USM;
+import org.snmp4j.security.UsmTimeEntry;
+import org.snmp4j.smi.Integer32;
+import org.snmp4j.smi.OctetString;
+
+import java.io.IOException;
+import java.util.List;
+
+final class PersistentUsm extends USM {
+    private static final Logger logger = LogManager.getLogger(PersistentUsm.class);
+
+    private final String persistencePath;
+    private final OctetString localEngineId;
+    private String persistedRemoteTimeSignature;
+
+    PersistentUsm(
+            final SecurityProtocols securityProtocols,
+            final OctetString localEngineId,
+            final int engineBoots,
+            final String persistencePath
+    ) {
+        super(securityProtocols, localEngineId, engineBoots);
+        this.persistencePath = persistencePath;
+        this.localEngineId = localEngineId;
+        restoreRemoteEngineTimeEntries();
+        this.persistedRemoteTimeSignature = EngineBootsStore.remoteEngineTimeSignature(getTimeTable(), localEngineId);
+    }
+
+    @Override
+    public int processIncomingMsg(
+            final int messageProcessingModel,
+            final int maxMessageSize,
+            final SecurityParameters securityParameters,
+            final SecurityModel securityModel,
+            final int securityLevel,
+            final BERInputStream wholeMsg,
+            final TransportStateReference tmStateReference,
+            final OctetString securityEngineID,
+            final OctetString securityName,
+            final BEROutputStream scopedPDU,
+            final Integer32 maxSizeResponseScopedPDU,
+            final SecurityStateReference securityStateReference,
+            final StatusInformation statusInformation
+    ) throws IOException {
+        final int status = super.processIncomingMsg(
+                messageProcessingModel,
+                maxMessageSize,
+                securityParameters,
+                securityModel,
+                securityLevel,
+                wholeMsg,
+                tmStateReference,
+                securityEngineID,
+                securityName,
+                scopedPDU,
+                maxSizeResponseScopedPDU,
+                securityStateReference,
+                statusInformation
+        );
+            logAuthoritativeEngineReportIfNeeded(status, securityEngineID, tmStateReference, securityName, statusInformation);
+        persistNow();
+        return status;
+    }
+
+    @Override
+    public void removeEngineTime(final OctetString engineId) {
+        super.removeEngineTime(engineId);
+        persistNow();
+    }
+
+    synchronized void persistNow() {
+        if (persistencePath == null || persistencePath.isBlank()) {
+            return;
+        }
+
+        final String currentRemoteTimeSignature = EngineBootsStore.remoteEngineTimeSignature(getTimeTable(), localEngineId);
+        if (currentRemoteTimeSignature.equals(persistedRemoteTimeSignature)) {
+            return;
+        }
+
+        EngineBootsStore.persistRemoteEngineTimeEntries(persistencePath, localEngineId, getTimeTable());
+        persistedRemoteTimeSignature = currentRemoteTimeSignature;
+    }
+
+    private void restoreRemoteEngineTimeEntries() {
+        final List<UsmTimeEntry> persistedRemoteEntries = EngineBootsStore.loadRemoteEngineTimeEntries(persistencePath, localEngineId);
+        persistedRemoteEntries.forEach(entry -> getTimeTable().addEntry(entry));
+    }
+
+    void logAuthoritativeEngineReportIfNeeded(
+            final int status,
+            final OctetString securityEngineId,
+            final TransportStateReference tmStateReference,
+            final OctetString securityName,
+            final StatusInformation statusInformation
+    ) {
+        if (status != SnmpConstants.SNMPv3_USM_NOT_IN_TIME_WINDOW || statusInformation == null) {
+            return;
+        }
+
+        final UsmTimeEntry incomingEngineTimeEntry = securityEngineId == null ? null : getTimeTable().getEntry(securityEngineId);
+        final Integer incomingEngineBoots = incomingEngineTimeEntry == null ? null : incomingEngineTimeEntry.getEngineBoots();
+        final Integer incomingEngineTime = incomingEngineTimeEntry == null ? null : incomingEngineTimeEntry.getLatestReceivedTime();
+
+        logger.info(
+            "SNMPv3 receiver returning REPORT after {}. local_engine_id={}, engine_boots={}, engine_time={}, incoming_engine_boots={}, incoming_engine_time={}, security_name={}, error_indication={}",
+            SnmpConstants.usmErrorMessage(status),
+                localEngineId.toHexString(),
+                getEngineBoots(),
+                getEngineTime(),
+                incomingEngineBoots,
+                incomingEngineTime,
+                securityName,
+                statusInformation.getErrorIndication()
+        );
+    }
+}

--- a/src/main/java/org/logstash/snmp/SnmpClient.java
+++ b/src/main/java/org/logstash/snmp/SnmpClient.java
@@ -239,7 +239,7 @@ public class SnmpClient implements Closeable {
 
     void doTrap(String[] communities, Consumer<SnmpTrapMessage> consumer, CountDownLatch stopCountDownLatch) throws IOException {
         final Set<String> allowedCommunities = Set.of(communities);
-        getSnmp().addCommandResponder(new CommandResponder() {
+        final CommandResponder trapResponder = new CommandResponder() {
             @Override
             public <A extends Address> void processPdu(final CommandResponderEvent<A> event) {
                 logger.debug("SNMP Trap received: {}", event);
@@ -263,7 +263,11 @@ public class SnmpClient implements Closeable {
 
                 consumer.accept(trapMessage);
             }
-        });
+        };
+
+        for (TransportMapping<? extends Address> transportMapping : getSnmp().getMessageDispatcher().getTransportMappings()) {
+            getSnmp().addNotificationListener(transportMapping, transportMapping.getListenAddress(), trapResponder);
+        }
 
         getSnmp().listen();
 

--- a/src/main/java/org/logstash/snmp/SnmpClient.java
+++ b/src/main/java/org/logstash/snmp/SnmpClient.java
@@ -116,6 +116,7 @@ public class SnmpClient implements Closeable {
             int messageDispatcherPoolSize,
             List<User> users,
             OctetString localEngineId,
+                String engineBootsPersistencePath,
             boolean mapOidVariableValues
     ) throws IOException {
         this.mib = mib;
@@ -144,6 +145,7 @@ public class SnmpClient implements Closeable {
                 users,
                 messageDispatcherPoolName,
                 messageDispatcherPoolSize
+                ,engineBootsPersistencePath
         );
     }
 
@@ -155,16 +157,20 @@ public class SnmpClient implements Closeable {
             OctetString localEngineId,
             List<User> users,
             String messageDispatcherPoolName,
-            int messageDispatcherPoolSize
+            int messageDispatcherPoolSize,
+            String engineBootsPersistencePath
     ) throws IOException {
-        final int engineBootCount = 0;
+        final int engineBootCount = supportedVersions.contains(SnmpConstants.version3)
+                ? EngineBootsStore.nextEngineBoots(engineBootsPersistencePath, localEngineId)
+                : 0;
         final MessageDispatcher messageDispatcher = createMessageDispatcher(
                 localEngineId,
                 supportedVersions,
                 users,
                 engineBootCount,
                 messageDispatcherPoolName,
-                messageDispatcherPoolSize
+            messageDispatcherPoolSize,
+            engineBootsPersistencePath
         );
 
         final Snmp snmp = new Snmp(messageDispatcher);
@@ -181,7 +187,8 @@ public class SnmpClient implements Closeable {
             List<User> users,
             int engineBootCount,
             String messageDispatcherPoolName,
-            int messageDispatcherPoolSize
+            int messageDispatcherPoolSize,
+            String engineBootsPersistencePath
     ) {
         final ThreadPool threadPool = ThreadPool.create(messageDispatcherPoolName, messageDispatcherPoolSize);
         final MessageDispatcherImpl dispatcherImpl = new MessageDispatcherImpl();
@@ -196,7 +203,7 @@ public class SnmpClient implements Closeable {
         }
 
         if (supportedVersions.contains(SnmpConstants.version3)) {
-            final MPv3 mpv3 = new MPv3(createUsm(users, localEngineId, engineBootCount));
+            final MPv3 mpv3 = new MPv3(createUsm(users, localEngineId, engineBootCount, engineBootsPersistencePath));
             mpv3.setCurrentMsgID(MPv3.randomMsgID(engineBootCount));
             dispatcher.addMessageProcessingModel(mpv3);
 
@@ -219,8 +226,8 @@ public class SnmpClient implements Closeable {
         return dispatcher;
     }
 
-    private static USM createUsm(List<User> users, OctetString localEngineID, int engineBootCount) {
-        final USM usm = new USM(SecurityProtocols.getInstance(), localEngineID, engineBootCount);
+    private static USM createUsm(List<User> users, OctetString localEngineID, int engineBootCount, String engineBootsPersistencePath) {
+        final USM usm = new PersistentUsm(SecurityProtocols.getInstance(), localEngineID, engineBootCount, engineBootsPersistencePath);
 
         if (users != null) {
             users.stream().map(User::getUsmUser).forEach(usm::addUser);
@@ -649,11 +656,19 @@ public class SnmpClient implements Closeable {
 
     private void closeSnmpClient() {
         try {
+            persistUsmState();
             snmp.close();
         } catch (Exception e) {
             logger.error("Error closing SNMP client", e);
         } finally {
             stopCountDownLatch.countDown();
+        }
+    }
+
+    private void persistUsmState() {
+        final USM usm = snmp.getUSM();
+        if (usm instanceof PersistentUsm) {
+            ((PersistentUsm) usm).persistNow();
         }
     }
 

--- a/src/main/java/org/logstash/snmp/SnmpClient.java
+++ b/src/main/java/org/logstash/snmp/SnmpClient.java
@@ -567,10 +567,12 @@ public class SnmpClient implements Closeable {
 
         final Address targetAddress = GenericAddress.parse(address);
         if (targetAddress == null) {
-            throw new IllegalArgumentException(String.format("Invalid or unknown host address: `%s`", address));
+            // For unknown/unresolvable hosts, parse the protocol and create the appropriate address type
+            // Resolution will be deferred until connection time
+            target.setAddress(createAddressForUnknownHost(address));
+        } else {
+            target.setAddress(targetAddress);
         }
-
-        target.setAddress(targetAddress);
         target.setVersion(snmpVersion);
         target.setRetries(retries);
         target.setTimeout(timeout);
@@ -612,6 +614,24 @@ public class SnmpClient implements Closeable {
                 return new TlsAddress(address);
             default:
                 throw new SnmpClientException(String.format("Invalid transport protocol specified '%s', expecting 'udp', 'tcp' or 'tls'", protocol));
+        }
+    }
+
+    private static Address createAddressForUnknownHost(String addressString) {
+        try {
+            // Try to extract protocol from address string (e.g., "udp:unknown/161")
+            if (addressString.startsWith("tcp:")) {
+                return new TcpAddress(addressString.substring(4));
+            } else if (addressString.startsWith("tls:")) {
+                return new TlsAddress(addressString.substring(4));
+            } else if (addressString.startsWith("udp:")) {
+                return new UdpAddress(addressString.substring(4));
+            } else {
+                // Default to UDP if no protocol specified
+                return new UdpAddress(addressString);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(String.format("Invalid or unknown host address: `%s`", addressString), e);
         }
     }
 

--- a/src/main/java/org/logstash/snmp/SnmpClientBuilder.java
+++ b/src/main/java/org/logstash/snmp/SnmpClientBuilder.java
@@ -48,6 +48,11 @@ public final class SnmpClientBuilder {
         return this;
     }
 
+    public SnmpClientBuilder setLocalEngineId(final byte[] localEngineId) {
+        this.localEngineId = new OctetString(localEngineId);
+        return this;
+    }
+
     public SnmpClientBuilder addUsmUser(
             String securityName,
             String authProtocol,

--- a/src/main/java/org/logstash/snmp/SnmpClientBuilder.java
+++ b/src/main/java/org/logstash/snmp/SnmpClientBuilder.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.logstash.snmp.SnmpUtils.parseAuthProtocol;
@@ -20,6 +21,8 @@ import static org.logstash.snmp.SnmpUtils.parsePrivProtocol;
 import static org.logstash.snmp.SnmpUtils.parseSecurityLevel;
 
 public final class SnmpClientBuilder {
+    private static final Pattern COLON_DELIMITED_HEX_BYTES = Pattern.compile("^(?i:[0-9a-f]{2}(?::[0-9a-f]{2})+)$");
+
     private final MibManager mib;
     private final int port;
     private OctetString localEngineId = new OctetString(MPv3.createLocalEngineID());
@@ -31,6 +34,8 @@ public final class SnmpClientBuilder {
     private String messageDispatcherPoolName = "SnmpMessageDispatcherWorker";
     private Duration closeTimeoutDuration;
     private boolean mapOidVariableValues = false;
+    private String engineBootsPersistencePath;
+    private boolean localEngineIdConfigured;
 
     public SnmpClientBuilder(MibManager mib, Set<String> supportedTransports, int port) {
         this.mib = mib;
@@ -44,12 +49,18 @@ public final class SnmpClientBuilder {
     }
 
     public SnmpClientBuilder setLocalEngineId(final String localEngineId) {
-        this.localEngineId = new OctetString(localEngineId);
+        if (COLON_DELIMITED_HEX_BYTES.matcher(localEngineId).matches()) {
+            this.localEngineId = OctetString.fromHexString(localEngineId, ':');
+        } else {
+            this.localEngineId = new OctetString(localEngineId);
+        }
+        this.localEngineIdConfigured = true;
         return this;
     }
 
     public SnmpClientBuilder setLocalEngineId(final byte[] localEngineId) {
         this.localEngineId = new OctetString(localEngineId);
+        this.localEngineIdConfigured = true;
         return this;
     }
 
@@ -106,7 +117,16 @@ public final class SnmpClientBuilder {
         return this;
     }
 
+    public SnmpClientBuilder setEngineBootsPersistencePath(final String engineBootsPersistencePath) {
+        this.engineBootsPersistencePath = engineBootsPersistencePath;
+        return this;
+    }
+
     public SnmpClient build() throws IOException {
+        if (!localEngineIdConfigured) {
+            localEngineId = EngineBootsStore.resolveLocalEngineId(engineBootsPersistencePath, localEngineId);
+        }
+
         final SnmpClient client = new SnmpClient(
                 mib,
                 supportedTransports,
@@ -117,6 +137,7 @@ public final class SnmpClientBuilder {
                 messageDispatcherPoolSize,
                 usmUsers,
                 localEngineId,
+                engineBootsPersistencePath,
                 mapOidVariableValues
         );
 

--- a/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
+++ b/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
@@ -170,7 +170,12 @@ public class SnmpTestTrapSender {
                 throw new RuntimeException(response.getError());
             }
 
-            return response != null && response.getResponse() != null;
+            if (response == null || response.getResponse() == null) {
+                return false;
+            }
+
+            final PDU responsePdu = response.getResponse();
+            return responsePdu.getErrorStatus() == PDU.noError;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
+++ b/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
@@ -77,7 +77,47 @@ public class SnmpTestTrapSender {
         send(pdu, target);
     }
 
+    public boolean sendInformV2c(String address, String community, Map<String, Object> bindings) {
+        final PDU pdu = new PDU();
+        pdu.setType(PDU.INFORM);
+        addVariableBindings(pdu, bindings);
+
+        final CommunityTarget<Address> target = new CommunityTarget<>(
+                GenericAddress.parse(address),
+                new OctetString(community)
+        );
+
+        target.setVersion(SnmpConstants.version2c);
+        target.setSecurityModel(SecurityModel.SECURITY_MODEL_SNMPv2c);
+        return send(pdu, target);
+    }
+
     public void sendTrapV3(
+            String address,
+            String securityName,
+            String authProtocol,
+            String authPassphrase,
+            String privProtocol,
+            String privPassphrase,
+            String securityLevel,
+            Map<String, Object> bindings) {
+        sendScopedPduV3(PDU.TRAP, address, securityName, authProtocol, authPassphrase, privProtocol, privPassphrase, securityLevel, bindings);
+    }
+
+    public boolean sendInformV3(
+            String address,
+            String securityName,
+            String authProtocol,
+            String authPassphrase,
+            String privProtocol,
+            String privPassphrase,
+            String securityLevel,
+            Map<String, Object> bindings) {
+        return sendScopedPduV3(PDU.INFORM, address, securityName, authProtocol, authPassphrase, privProtocol, privPassphrase, securityLevel, bindings);
+    }
+
+    private boolean sendScopedPduV3(
+            int pduType,
             String address,
             String securityName,
             String authProtocol,
@@ -99,7 +139,7 @@ public class SnmpTestTrapSender {
             snmp.getMessageDispatcher().addMessageProcessingModel(new MPv3(usm));
 
             final ScopedPDU pdu = new ScopedPDU();
-            pdu.setType(PDU.TRAP);
+            pdu.setType(pduType);
             addVariableBindings(pdu, bindings);
 
             final Target<Address> target = new UserTarget<>();
@@ -109,7 +149,7 @@ public class SnmpTestTrapSender {
             target.setVersion(SnmpConstants.version3);
             target.setSecurityModel(SecurityModel.SECURITY_MODEL_USM);
 
-            send(pdu, target);
+            return send(pdu, target);
         } finally {
             cleanupSnmpMessageDispatcherMPv3Model();
         }
@@ -123,12 +163,14 @@ public class SnmpTestTrapSender {
         }
     }
 
-    private void send(PDU pdu, Target<Address> target) {
+    private boolean send(PDU pdu, Target<Address> target) {
         try {
             final ResponseEvent<Address> response = snmp.send(pdu, target);
             if (response != null && response.getError() != null) {
                 throw new RuntimeException(response.getError());
             }
+
+            return response != null && response.getResponse() != null;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
+++ b/src/main/java/org/logstash/snmp/SnmpTestTrapSender.java
@@ -30,6 +30,7 @@ import org.snmp4j.transport.DefaultUdpTransportMapping;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -48,7 +49,11 @@ public class SnmpTestTrapSender {
     private final Snmp snmp;
 
     public SnmpTestTrapSender(int port) {
-        this.snmp = createSnmpSession(port);
+        this(createSnmpSession(port));
+    }
+
+    SnmpTestTrapSender(Snmp snmp) {
+        this.snmp = Objects.requireNonNull(snmp);
     }
 
     public void sendTrapV1(String address, String community, Map<String, Object> bindings) {
@@ -174,8 +179,7 @@ public class SnmpTestTrapSender {
                 return false;
             }
 
-            final PDU responsePdu = response.getResponse();
-            return responsePdu.getErrorStatus() == PDU.noError;
+            return response.getResponse().getErrorStatus() == PDU.noError;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/logstash/snmp/SnmpClientTest.java
+++ b/src/test/java/org/logstash/snmp/SnmpClientTest.java
@@ -10,6 +10,7 @@ import org.logstash.snmp.mib.MibManager;
 import org.logstash.snmp.trap.SnmpTrapMessage;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
+import org.snmp4j.CommandResponder;
 import org.snmp4j.CommandResponderEvent;
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.MessageDispatcher;
@@ -867,16 +868,17 @@ class SnmpClientTest {
     }
 
     @Test
-    void trapShouldAddCommandResponderAndListen() throws Exception {
+    void trapShouldAddNotificationListenerAndListen() throws Exception {
         try (final SnmpClient client = spy(createClient())) {
             final Snmp snmp = spy(client.getSnmp());
             when(client.getSnmp()).thenReturn(snmp);
 
             doNothing().when(snmp).listen();
+            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             client.doTrap(new String[0], ignore -> {/*Empty*/}, new CountDownLatch(0));
 
-            verify(snmp).addCommandResponder(any());
+            verify(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
             verify(snmp).listen();
         }
     }
@@ -918,6 +920,7 @@ class SnmpClientTest {
             final Snmp snmp = spy(client.getSnmp());
             when(client.getSnmp()).thenReturn(snmp);
             doNothing().when(snmp).listen();
+            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             final boolean[] called = new boolean[1];
             // Start traps client with non-blocking latch
@@ -936,7 +939,7 @@ class SnmpClientTest {
                     .thenReturn(new PDUv1());
 
             // Simulates an incoming trap message
-            snmp.processPdu(responderEvent);
+            captureNotificationListener(snmp).processPdu(responderEvent);
 
             assertEquals(callExpected, called[0]);
 
@@ -1141,6 +1144,7 @@ class SnmpClientTest {
 
             when(client.getSnmp()).thenReturn(snmp);
             doNothing().when(snmp).listen();
+            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             final SnmpTrapMessage[] message = new SnmpTrapMessage[1];
             client.doTrap(new String[0], p -> message[0] = p, new CountDownLatch(0));
@@ -1162,7 +1166,7 @@ class SnmpClientTest {
                     .thenReturn(securityLevel);
 
             // Simulates an incoming trap message
-            snmp.processPdu(responderEvent);
+            captureNotificationListener(snmp).processPdu(responderEvent);
 
             final SnmpTrapMessage snmpTrapMessage = message[0];
             assertNotNull(snmpTrapMessage);
@@ -1172,6 +1176,12 @@ class SnmpClientTest {
 
             return snmpTrapMessage;
         }
+    }
+
+    private CommandResponder captureNotificationListener(Snmp snmp) throws IOException {
+        final ArgumentCaptor<CommandResponder> captor = ArgumentCaptor.forClass(CommandResponder.class);
+        verify(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), captor.capture());
+        return captor.getValue();
     }
 
     @ParameterizedTest

--- a/src/test/java/org/logstash/snmp/SnmpClientTest.java
+++ b/src/test/java/org/logstash/snmp/SnmpClientTest.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.logstash.snmp.mib.MibManager;
@@ -19,12 +20,14 @@ import org.snmp4j.PDUv1;
 import org.snmp4j.ScopedPDU;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
+import org.snmp4j.TransportStateReference;
 import org.snmp4j.TransportMapping;
 import org.snmp4j.UserTarget;
 import org.snmp4j.event.ResponseEvent;
 import org.snmp4j.mp.MPv1;
 import org.snmp4j.mp.MPv2c;
 import org.snmp4j.mp.MPv3;
+import org.snmp4j.mp.StatusInformation;
 import org.snmp4j.mp.SnmpConstants;
 import org.snmp4j.security.AuthHMAC192SHA256;
 import org.snmp4j.security.AuthMD5;
@@ -36,6 +39,7 @@ import org.snmp4j.security.SecurityModels;
 import org.snmp4j.security.SecurityProtocols;
 import org.snmp4j.security.TSM;
 import org.snmp4j.security.USM;
+import org.snmp4j.security.UsmTimeEntry;
 import org.snmp4j.security.UsmUser;
 import org.snmp4j.security.UsmUserEntry;
 import org.snmp4j.smi.Address;
@@ -63,6 +67,7 @@ import org.snmp4j.util.TreeEvent;
 import org.snmp4j.util.TreeUtils;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -84,6 +89,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -96,6 +102,15 @@ class SnmpClientTest {
     private static final String HOST_ADDRESS = "localhost/161";
     private static final int PORT = 1069;
     private static final String LOCAL_ENGINE_ID = new String(MPv3.createLocalEngineID());
+    private static final String HEX_LOCAL_ENGINE_ID = "80:00:1f:88:80:50:09:d7:68:be:4f:d5:69:00:00:00:00";
+    private static final byte[] HEX_LOCAL_ENGINE_ID_BYTES = new byte[]{
+            (byte) 0x80, 0x00, 0x1f, (byte) 0x88, (byte) 0x80, 0x50, 0x09, (byte) 0xd7,
+            0x68, (byte) 0xbe, 0x4f, (byte) 0xd5, 0x69, 0x00, 0x00, 0x00, 0x00
+    };
+        private static final OctetString REMOTE_ENGINE_ID = new OctetString(new byte[]{
+            (byte) 0x80, 0x00, 0x1f, (byte) 0x88, (byte) 0x80, 0x50, 0x09, (byte) 0xd7,
+            0x68, (byte) 0xbe, 0x4f, (byte) 0xd5, 0x69, 0x00, 0x00, 0x00, 0x01
+        });
     private static final UsmUser USER = new UsmUser(
             new OctetString("admin"),
             AuthMD5.ID,
@@ -110,6 +125,9 @@ class SnmpClientTest {
 
     @RegisterExtension
     LoggerAppenderExtension loggerExt = new LoggerAppenderExtension(LogManager.getLogger(SnmpClient.class));
+
+    @RegisterExtension
+    LoggerAppenderExtension persistentUsmLoggerExt = new LoggerAppenderExtension(LogManager.getLogger(PersistentUsm.class));
 
     @Test
     void shouldAddByDefaultAllSnmpMessageDispatcherProcessingModels() throws IOException {
@@ -216,6 +234,112 @@ class SnmpClientTest {
             assertNotNull(mpv3);
             assertArrayEquals(LOCAL_ENGINE_ID.getBytes(), mpv3.getLocalEngineID());
         }
+    }
+
+    @Test
+    void shouldParseHexEncodedSnmpMPv3LocalEngineId() throws IOException {
+        final SnmpClientBuilder builder = createClientBuilder(Set.of("udp"))
+                .setLocalEngineId(HEX_LOCAL_ENGINE_ID);
+
+        try (final SnmpClient client = builder.build()) {
+            final MPv3 mpv3 = (MPv3) client.getSnmp().getMessageProcessingModel(MPv3.ID);
+            assertNotNull(mpv3);
+            assertArrayEquals(HEX_LOCAL_ENGINE_ID_BYTES, mpv3.getLocalEngineID());
+        }
+    }
+
+    @Test
+    void shouldPersistLocalEngineBootsAcrossRestarts(@TempDir final Path tempDir) throws IOException {
+        final String persistencePath = tempDir.resolve("snmp.engineboots").toString();
+        byte[] firstLocalEngineId;
+
+        try (final SnmpClient firstClient = createAutoLocalEngineIdClientBuilder(Set.of("udp"))
+                .setSupportedVersions(Set.of("3"))
+                .setEngineBootsPersistencePath(persistencePath)
+                .build()) {
+            assertEquals(0, firstClient.getSnmp().getUSM().getEngineBoots());
+            final MPv3 mpv3 = (MPv3) firstClient.getSnmp().getMessageProcessingModel(MPv3.ID);
+            assertNotNull(mpv3);
+            firstLocalEngineId = mpv3.getLocalEngineID();
+        }
+
+        try (final SnmpClient secondClient = createAutoLocalEngineIdClientBuilder(Set.of("udp"))
+                .setSupportedVersions(Set.of("3"))
+                .setEngineBootsPersistencePath(persistencePath)
+                .build()) {
+            final MPv3 mpv3 = (MPv3) secondClient.getSnmp().getMessageProcessingModel(MPv3.ID);
+            assertNotNull(mpv3);
+            assertArrayEquals(firstLocalEngineId, mpv3.getLocalEngineID());
+            assertEquals(1, secondClient.getSnmp().getUSM().getEngineBoots());
+        }
+    }
+
+    @Test
+    void shouldPersistRemoteEngineTimeEntriesAcrossRestarts(@TempDir final Path tempDir) throws IOException {
+        final String persistencePath = tempDir.resolve("snmp.engineboots").toString();
+        final UsmTimeEntry remoteEngineTime = new UsmTimeEntry(REMOTE_ENGINE_ID, 7, 900);
+        final int expectedTimeDiff = remoteEngineTime.getTimeDiff();
+
+        try (final SnmpClient firstClient = createAutoLocalEngineIdClientBuilder(Set.of("udp"))
+                .setSupportedVersions(Set.of("3"))
+                .setEngineBootsPersistencePath(persistencePath)
+                .build()) {
+            firstClient.getSnmp().getUSM().getTimeTable().addEntry(remoteEngineTime);
+        }
+
+        try (final SnmpClient secondClient = createAutoLocalEngineIdClientBuilder(Set.of("udp"))
+                .setSupportedVersions(Set.of("3"))
+                .setEngineBootsPersistencePath(persistencePath)
+                .build()) {
+            final UsmTimeEntry restoredRemoteEngineTime = secondClient.getSnmp().getUSM().getTimeTable().getEntry(REMOTE_ENGINE_ID);
+
+            assertNotNull(restoredRemoteEngineTime);
+            assertEquals(7, restoredRemoteEngineTime.getEngineBoots());
+            assertEquals(expectedTimeDiff, restoredRemoteEngineTime.getTimeDiff());
+        }
+    }
+
+    @Test
+    void shouldLogLocalAndIncomingAuthoritativeValuesWhenReturningReportForNotInTimeWindow() {
+        final PersistentUsm usm = new PersistentUsm(SecurityProtocols.getInstance(), new OctetString(LOCAL_ENGINE_ID), 3, null);
+        final UsmTimeEntry incomingEngineTimeEntry = new UsmTimeEntry(REMOTE_ENGINE_ID, 7, 900);
+        final StatusInformation statusInformation = new StatusInformation();
+        final VariableBinding errorIndication = new VariableBinding(SnmpConstants.usmStatsNotInTimeWindows, new Integer32(0));
+        final TransportStateReference tmStateReference = new TransportStateReference(
+            null,
+            TRAP_PEER_ADDRESS,
+            null,
+            null,
+            null,
+            false,
+            null
+        );
+
+        usm.getTimeTable().addEntry(incomingEngineTimeEntry);
+        statusInformation.setErrorIndication(errorIndication);
+
+        usm.logAuthoritativeEngineReportIfNeeded(
+            SnmpConstants.SNMPv3_USM_NOT_IN_TIME_WINDOW,
+            REMOTE_ENGINE_ID,
+            tmStateReference,
+            USER.getSecurityName(),
+            statusInformation
+        );
+
+        persistentUsmLoggerExt.getAppender().assertLog(
+            PersistentUsm.class,
+            Level.INFO,
+            event -> {
+                final String message = event.getMessage().getFormattedMessage();
+                return message.contains("receiver returning REPORT after")
+                    && message.contains(new OctetString(LOCAL_ENGINE_ID).toHexString())
+                    && message.contains("engine_boots=3")
+                    && message.contains("incoming_engine_boots=7")
+                    && message.contains("incoming_engine_time=900")
+                    && message.contains(USER.getSecurityName().toString())
+                    && message.contains(SnmpConstants.usmErrorMessage(SnmpConstants.SNMPv3_USM_NOT_IN_TIME_WINDOW));
+            }
+        );
     }
 
     @Test
@@ -874,7 +998,7 @@ class SnmpClientTest {
             when(client.getSnmp()).thenReturn(snmp);
 
             doNothing().when(snmp).listen();
-            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
+            doReturn(true).when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             client.doTrap(new String[0], ignore -> {/*Empty*/}, new CountDownLatch(0));
 
@@ -920,7 +1044,7 @@ class SnmpClientTest {
             final Snmp snmp = spy(client.getSnmp());
             when(client.getSnmp()).thenReturn(snmp);
             doNothing().when(snmp).listen();
-            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
+            doReturn(true).when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             final boolean[] called = new boolean[1];
             // Start traps client with non-blocking latch
@@ -1144,7 +1268,7 @@ class SnmpClientTest {
 
             when(client.getSnmp()).thenReturn(snmp);
             doNothing().when(snmp).listen();
-            doNothing().when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
+            doReturn(true).when(snmp).addNotificationListener(any(TransportMapping.class), any(Address.class), any(CommandResponder.class));
 
             final SnmpTrapMessage[] message = new SnmpTrapMessage[1];
             client.doTrap(new String[0], p -> message[0] = p, new CountDownLatch(0));
@@ -1197,14 +1321,11 @@ class SnmpClientTest {
     }
 
     @Test
-    void createTargetWithUnknownHostShouldThrow() throws IOException {
+    void createTargetWithUnknownHostShouldCreateTarget() throws IOException {
         try (SnmpClient client = createClient()) {
-            final IllegalArgumentException exception = assertThrows(
-                    IllegalArgumentException.class,
-                    () -> client.createTarget("udp:unknown/161", "1", 1, 1, "public", null, null)
-            );
+            final Target<Address> target = client.createTarget("udp:unknown/161", "1", 1, 1, "public", null, null);
 
-            assertEquals("Invalid or unknown host address: `udp:unknown/161`", exception.getMessage());
+            assertEquals(GenericAddress.parse("udp:unknown/161"), target.getAddress());
         }
     }
 
@@ -1290,6 +1411,19 @@ class SnmpClientTest {
                 .setMessageDispatcherPoolName("FooBarWorker")
                 .setMessageDispatcherPoolSize(1)
                 .setLocalEngineId(LOCAL_ENGINE_ID)
+                .addUsmUser(
+                        USER.getSecurityName().toString(),
+                        "md5",
+                        USER.getAuthenticationPassphrase().toString(),
+                        "des",
+                        USER.getPrivacyPassphrase().toString(),
+                        "authNoPriv");
+    }
+
+    private SnmpClientBuilder createAutoLocalEngineIdClientBuilder(Set<String> protocols) {
+        return creatEmptyClientBuilder(mibManager, protocols, PORT)
+                .setMessageDispatcherPoolName("FooBarWorker")
+                .setMessageDispatcherPoolSize(1)
                 .addUsmUser(
                         USER.getSecurityName().toString(),
                         "md5",

--- a/src/test/java/org/logstash/snmp/SnmpTestTrapSenderTest.java
+++ b/src/test/java/org/logstash/snmp/SnmpTestTrapSenderTest.java
@@ -1,0 +1,67 @@
+package org.logstash.snmp;
+
+import org.junit.jupiter.api.Test;
+import org.snmp4j.PDU;
+import org.snmp4j.Snmp;
+import org.snmp4j.event.ResponseEvent;
+import org.snmp4j.smi.Address;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SnmpTestTrapSenderTest {
+
+    @Test
+    void sendInformV2cReturnsTrueWhenResponseHasNoSnmpError() throws IOException {
+        final Snmp snmp = mock(Snmp.class);
+        final ResponseEvent<Address> response = mock(ResponseEvent.class);
+        final PDU responsePdu = new PDU();
+        responsePdu.setErrorStatus(PDU.noError);
+
+        when(snmp.send(any(PDU.class), any())).thenReturn(response);
+        when(response.getResponse()).thenReturn(responsePdu);
+
+        final SnmpTestTrapSender sender = new SnmpTestTrapSender(snmp);
+
+        assertTrue(sender.sendInformV2c("udp:127.0.0.1/161", "public", Map.of("1.3.6.1.2.1.1.1.0", "ok")));
+    }
+
+    @Test
+    void sendInformV2cReturnsFalseWhenResponsePduReportsError() throws IOException {
+        final Snmp snmp = mock(Snmp.class);
+        final ResponseEvent<Address> response = mock(ResponseEvent.class);
+        final PDU responsePdu = new PDU();
+        responsePdu.setErrorStatus(PDU.authorizationError);
+
+        when(snmp.send(any(PDU.class), any())).thenReturn(response);
+        when(response.getResponse()).thenReturn(responsePdu);
+
+        final SnmpTestTrapSender sender = new SnmpTestTrapSender(snmp);
+
+        assertFalse(sender.sendInformV2c("udp:127.0.0.1/161", "public", Map.of("1.3.6.1.2.1.1.1.0", "error")));
+    }
+
+    @Test
+    void sendInformV2cRaisesWhenResponseEventContainsTransportError() throws IOException {
+        final Snmp snmp = mock(Snmp.class);
+        final ResponseEvent<Address> response = mock(ResponseEvent.class);
+        final IOException transportError = new IOException("transport failure");
+
+        when(snmp.send(any(PDU.class), any())).thenReturn(response);
+        when(response.getError()).thenReturn(transportError);
+
+        final SnmpTestTrapSender sender = new SnmpTestTrapSender(snmp);
+
+        final RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> sender.sendInformV2c("udp:127.0.0.1/161", "public", Map.of("1.3.6.1.2.1.1.1.0", "error")));
+
+        assertTrue(exception.getCause() instanceof IOException);
+    }
+}


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
Support SNMPv3 Informs. The plugins is able to set up engine id using local_engine_id and send ack to the SNMP agent.